### PR TITLE
[feat/#2] 커스텀 탭바 구현

### DIFF
--- a/Solply/Solply/Application/SolplyApp.swift
+++ b/Solply/Solply/Application/SolplyApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct SolplyApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            TabBarView()
         }
     }
 }

--- a/Solply/Solply/Global/Enum/TabBarState.swift
+++ b/Solply/Solply/Global/Enum/TabBarState.swift
@@ -1,0 +1,20 @@
+//
+//  TabBarState.swift
+//  Solply
+//
+//  Created by 김승원 on 6/27/25.
+//
+
+import Foundation
+
+enum TabBarState: CaseIterable {
+    case place
+    case course
+    
+    var title: String {
+        switch self {
+        case .place: return "장소"
+        case .course: return "코스"
+        }
+    }
+}

--- a/Solply/Solply/Global/Enum/TempEnum.swift
+++ b/Solply/Solply/Global/Enum/TempEnum.swift
@@ -1,8 +1,0 @@
-//
-//  TempEnum.swift
-//  Solply
-//
-//  Created by 김승원 on 6/27/25.
-//
-
-import Foundation

--- a/Solply/Solply/Global/Util/CustomNavigationBarModifier.swift
+++ b/Solply/Solply/Global/Util/CustomNavigationBarModifier.swift
@@ -39,9 +39,8 @@ struct CustomNavigationBarModifier<C, L, R>: ViewModifier where C: View, L: View
                 self.centerView?()
                 
             }
-            /*
-             Todo: 네비게이션 패딩값 나오면 수정 필요
-             */
+            
+            // TODO: 네비게이션 패딩값 나오면 수정 필요
             .padding(.horizontal, 0)
             .padding(.vertical, 0)
             .background(backgroundColor)

--- a/Solply/Solply/Global/Util/RoundedCorner.swift
+++ b/Solply/Solply/Global/Util/RoundedCorner.swift
@@ -38,4 +38,9 @@ extension View {
     func capsuleClipped() -> some View {
         self.clipShape(Capsule())
     }
+    
+    /// 뷰 전체를 원형 형태로 자릅니다.
+    func circleClipped() -> some View {
+        self.clipShape(Circle())
+    }
 }

--- a/Solply/Solply/Presentation/Core/Component/MyPageButton.swift
+++ b/Solply/Solply/Presentation/Core/Component/MyPageButton.swift
@@ -1,0 +1,36 @@
+//
+//  MyPageButton.swift
+//  Solply
+//
+//  Created by 김승원 on 6/27/25.
+//
+
+import SwiftUI
+
+struct MyPageButton: View {
+    
+    // MARK: - Properties
+    
+    private let onTap: (() -> Void)?
+    
+    // MARK: - Initializer
+    
+    init(onTap: (() -> Void)?) {
+        self.onTap = onTap
+    }
+    
+    // MARK: - Body
+    
+    var body: some View {
+        Button {
+            onTap?()
+        } label: {
+            Image(systemName: "house.fill")
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 50.adjustedWidth, height: 50.adjustedHeight)
+                .background(Color(.systemGray5))
+                .circleClipped()
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Solply/Solply/Presentation/Core/Component/SolplyTabBar.swift
+++ b/Solply/Solply/Presentation/Core/Component/SolplyTabBar.swift
@@ -1,0 +1,65 @@
+//
+//  SolplyTabBar.swift
+//  Solply
+//
+//  Created by 김승원 on 6/27/25.
+//
+
+import SwiftUI
+
+struct SolplyTabBar: View {
+    
+    // MARK: - Properties
+    
+    @State private var selectedTab: TabBarState = .place
+    private let tabItemCapsuleWidth: CGFloat = 81.adjustedWidth
+    private let tabItemCapsuleHeight: CGFloat = 42.adjustedHeight
+    
+    // MARK: - Body
+    
+    var body: some View {
+        ZStack(alignment: .leading) {
+            tabItemCapsule
+            
+            HStack(spacing: 0) {
+                ForEach(TabBarState.allCases, id: \.self) { tab in
+                    TabItem(
+                        selectedTab: $selectedTab,
+                        tab: tab,
+                        width: tabItemCapsuleWidth,
+                        height: tabItemCapsuleHeight
+                    )
+                }
+            }
+        }
+        .padding(.horizontal, 4.adjustedWidth)
+        .padding(.vertical, 4.adjustedHeight)
+        .background(Color(.systemGray5))
+        .capsuleClipped()
+    }
+}
+
+// MARK: - Subviews
+
+extension SolplyTabBar {
+    private var tabItemCapsule: some View {
+        Capsule()
+            .fill(Color(.systemGray3))
+            .frame(width: tabItemCapsuleWidth, height: tabItemCapsuleHeight)
+            .offset(x: capsuleOffsetX(for: selectedTab))
+            .animation(.easeInOut(duration: 0.2), value: selectedTab)
+    }
+}
+
+// MARK: - Functions
+
+extension SolplyTabBar {
+    private func capsuleOffsetX(for tab: TabBarState) -> CGFloat {
+        let index = TabBarState.allCases.firstIndex(of: tab) ?? 0
+        return CGFloat(index) * tabItemCapsuleWidth
+    }
+}
+
+#Preview {
+    SolplyTabBar()
+}

--- a/Solply/Solply/Presentation/Core/Component/SolplyTabBar.swift
+++ b/Solply/Solply/Presentation/Core/Component/SolplyTabBar.swift
@@ -14,6 +14,13 @@ struct SolplyTabBar: View {
     @State private var selectedTab: TabBarState = .place
     private let tabItemCapsuleWidth: CGFloat = 81.adjustedWidth
     private let tabItemCapsuleHeight: CGFloat = 42.adjustedHeight
+    private let onTap: ((TabBarState) -> Void)?
+    
+    // MARK: - Initializer
+    
+    init(onTap: ((TabBarState) -> Void)?) {
+        self.onTap = onTap
+    }
     
     // MARK: - Body
     
@@ -28,7 +35,9 @@ struct SolplyTabBar: View {
                         tab: tab,
                         width: tabItemCapsuleWidth,
                         height: tabItemCapsuleHeight
-                    )
+                    ) {
+                        onTap?(tab)
+                    }
                 }
             }
         }
@@ -58,8 +67,4 @@ extension SolplyTabBar {
         let index = TabBarState.allCases.firstIndex(of: tab) ?? 0
         return CGFloat(index) * tabItemCapsuleWidth
     }
-}
-
-#Preview {
-    SolplyTabBar()
 }

--- a/Solply/Solply/Presentation/Core/Component/TabItem.swift
+++ b/Solply/Solply/Presentation/Core/Component/TabItem.swift
@@ -1,0 +1,40 @@
+//
+//  TabItem.swift
+//  Solply
+//
+//  Created by 김승원 on 6/27/25.
+//
+
+import SwiftUI
+
+struct TabItem: View {
+    
+    // MARK: - Properties
+    
+    @Binding private var selectedTab: TabBarState
+    private let tab: TabBarState
+    private let width: CGFloat
+    private let height: CGFloat
+    
+    // MARK: - Initializer
+    
+    init(selectedTab: Binding<TabBarState>, tab: TabBarState, width: CGFloat, height: CGFloat) {
+        self._selectedTab = selectedTab
+        self.tab = tab
+        self.width = width
+        self.height = height
+    }
+    
+    // MARK: - Body
+    
+    var body: some View {
+        Button {
+            selectedTab = tab
+        } label: {
+            Text(tab.title)
+                .frame(width: 81.adjustedWidth, height: 42.adjustedHeight)
+                .foregroundColor(selectedTab == tab ? .black : .gray)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Solply/Solply/Presentation/Core/Component/TabItem.swift
+++ b/Solply/Solply/Presentation/Core/Component/TabItem.swift
@@ -15,14 +15,22 @@ struct TabItem: View {
     private let tab: TabBarState
     private let width: CGFloat
     private let height: CGFloat
+    private let onTap: (() -> Void)?
     
     // MARK: - Initializer
     
-    init(selectedTab: Binding<TabBarState>, tab: TabBarState, width: CGFloat, height: CGFloat) {
+    init(
+        selectedTab: Binding<TabBarState>,
+        tab: TabBarState,
+        width: CGFloat,
+        height: CGFloat,
+        onTap: (() -> Void)?
+    ) {
         self._selectedTab = selectedTab
         self.tab = tab
         self.width = width
         self.height = height
+        self.onTap = onTap
     }
     
     // MARK: - Body
@@ -30,9 +38,10 @@ struct TabItem: View {
     var body: some View {
         Button {
             selectedTab = tab
+            onTap?()
         } label: {
             Text(tab.title)
-                .frame(width: 81.adjustedWidth, height: 42.adjustedHeight)
+                .frame(width: width, height: height)
                 .foregroundColor(selectedTab == tab ? .black : .gray)
         }
         .buttonStyle(.plain)

--- a/Solply/Solply/Presentation/Core/CoreTemp.swift
+++ b/Solply/Solply/Presentation/Core/CoreTemp.swift
@@ -1,8 +1,0 @@
-//
-//  CoreTemp.swift
-//  Solply
-//
-//  Created by 김승원 on 6/27/25.
-//
-
-import Foundation

--- a/Solply/Solply/Presentation/Core/TabBarView.swift
+++ b/Solply/Solply/Presentation/Core/TabBarView.swift
@@ -1,0 +1,52 @@
+//
+//  TabBarView.swift
+//  Solply
+//
+//  Created by 김승원 on 6/27/25.
+//
+
+import SwiftUI
+
+struct TabBarView: View {
+    
+    // MARK: - Body
+    
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            Text("hello")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(.red)
+            
+            tabBar
+                .padding(.bottom, 16.adjustedHeight)
+        }
+    }
+}
+
+// MARK: - Subviews
+
+extension TabBarView {
+    private var tabBar: some View {
+        ZStack(alignment: .center) {
+            HStack(alignment: .center, spacing: 0) {
+                Spacer()
+                
+                MyPageButton {
+                    // TODO: 마이페이지(수집함) 연결
+                    print("마이페이지 탭")
+                }
+            }
+            .padding(.horizontal, 23.adjustedWidth)
+            
+            SolplyTabBar { tab in
+                // TODO: tab에 따라 장소, 코스 연결
+                print("\(tab.title) 탭")
+            }
+        }
+        .background(.blue)
+    }
+}
+
+#Preview {
+    TabBarView()
+}


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 커스텀 탭바를 구현했습니다.
- 화면 이동은 Navigation Coordinator 구현과 함께 구현하겠습니다.
- 와이어 프레임을 기준으로 작업했기 때문에, 디자인 확정 후 수정할 예정입니다.
- 아직 디자인 시스템이 안 나왔기 때문에, 폰트, 아이콘은 기기대응하지 않았습니다.

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| 탭바 | <img src = "https://github.com/user-attachments/assets/f1bd2d69-530c-4599-8225-3676fb2eec04" width ="250"> | <img src = "https://github.com/user-attachments/assets/48aabc8b-81fa-4c89-822c-d1d17774eeaf" width ="250"> |


## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 탭바 구성
<img src = "https://github.com/user-attachments/assets/a97bf8fe-85c2-42b0-a9e0-05df2f86fba4" width = "400">

쉽게 설명하기 위해 간단한 그래프를 그려왔습니다.
`TabBarView`가 화면에 나타낼 뷰와 탭바를 가지고 있는 최상단 객체이며, 이곳에서 탭바 화면 전환 & 이동을 관리할 예정입니다!
`SolplyTabBar`가 장소와 코스 탭이 있는 객체, 그리고 `MyPageButton`은 따로 분리해 뒀습니다.
마지막으로 `TabItem`는 `SolplyTabBar`가 가지고 있는 장소, 코스 탭을 구현하는 컴포넌트입니다.
<br>
위 처럼 수집함 버튼을 따로 분리한 이유는, 수집함 버튼을 눌렀을 때 View 교체가 아닌, navigate가 되어야 하기 때문에
버튼으로 분리했어요

### 애니메이션 구현 방법
```Swift
// SolplyTabBar.swift

extension SolplyTabBar {
    private var tabItemCapsule: some View {
        Capsule()
            .fill(Color(.systemGray3))
            .frame(width: tabItemCapsuleWidth, height: tabItemCapsuleHeight)
            .offset(x: capsuleOffsetX(for: selectedTab))
            .animation(.easeInOut(duration: 0.2), value: selectedTab)
    }
}

extension SolplyTabBar {
    private func capsuleOffsetX(for tab: TabBarState) -> CGFloat {
        let index = TabBarState.allCases.firstIndex(of: tab) ?? 0
        return CGFloat(index) * tabItemCapsuleWidth
    }
}
```
`SolplyTabBar`에 탭바를  `tabItemCapsule`(배경) 따로, 그리고 `TabItem` 따로 `ZStack`으로 배치했어요
사용자가 `TabItem`을 누르면 `tabItem`의 `offset`값을 변경하여 애니메이션을 구현했습니다.
현재 선택된 `tab`의 인덱스를 활용해, x `offset`값을 계산하였어요

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #2 