### PR TITLE
[feat/#29] 장소 유형 enum 구현

### DIFF
--- a/Solply/Solply/Global/Enum/PlaceCategoryType.swift
+++ b/Solply/Solply/Global/Enum/PlaceCategoryType.swift
@@ -1,0 +1,54 @@
+//
+//  PlaceCategoryType.swift
+//  Solply
+//
+//  Created by seozero on 7/8/25.
+//
+
+import SwiftUI
+
+enum PlaceCategoryType {
+    case all
+    case cafe
+    case food
+    case book
+    case shopping
+    case walk
+    case unique
+    
+    var title: String {
+        switch self {
+        case .all: return "전체"
+        case .cafe: return "카페"
+        case .food: return "음식"
+        case .book: return "서점/책방"
+        case .shopping: return "쇼핑"
+        case .walk: return "산책"
+        case .unique: return "이색공간"
+        }
+    }
+    
+    var backgroundColor: Color? {
+        switch self {
+        case .all: return nil
+        case .cafe: return .red100
+        case .food: return .yellow100
+        case .book: return .purple100
+        case .shopping: return .purple100
+        case .walk: return .green100
+        case .unique: return .green100
+        }
+    }
+    
+    var titleColor: Color? {
+        switch self {
+        case .all: return nil
+        case .cafe: return .red500
+        case .food: return .yellow500
+        case .book: return .purple600
+        case .shopping: return .purple600
+        case .walk: return .green500
+        case .unique: return .green500
+        }
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 장소 유형을 enum 타입으로 구현했습니다.
- title, backgroundColor, titleColor도 enum으로 관리합니다. 

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 장소 유형 enum 타입 구현
```Swift
var backgroundColor: Color? {
    switch self {
    case .all: return nil
    case .cafe: return .red100
    case .food: return .yellow100
    case .book: return .purple100
    case .shopping: return .purple100
    case .walk: return .green100
    case .unique: return .green100
    }
}
```
장소 유형 중에 **전체**가 포함되어 있는데, 설정해줄 `backgroundColor`나 `titleColor`는 없어서
Color를 옵셔널로 설정했습니다. **전체**의 color들은 `nil`로 설정해주었습니다.

`book`과 `shopping`, `walk`과 `unique`는 같은 컬러를 사용하고 있지만, 
추후 스프린트를 통해 변경사항이 생길 수도 있기 때문에 따로 관리해주기로 했습니다 !

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #29 