### PR TITLE
[feat/#19] 커스텀 네비게이션 바 구현

### DIFF
--- a/Solply/Solply/Global/Enum/NavigationBarType.swift
+++ b/Solply/Solply/Global/Enum/NavigationBarType.swift
@@ -1,0 +1,18 @@
+//
+//  NavigationBarType.swift
+//  Solply
+//
+//  Created by 김승원 on 7/8/25.
+//
+
+import Foundation
+
+/// 네비게이션 바 타입입니다.
+enum NavigationBarType {
+    case onboarding(backAction: () -> Void)
+    case recommend(filterTitle: String, filterAction: () -> Void, settingAction: () -> Void)
+    case placeDetail(title: String, backAction: () -> Void, homeAction: () -> Void)
+    case courseDetail(backAction: () -> Void, homeAction: () -> Void)
+    case archive(backAction: () -> Void)
+    case archiveList(title: String, backAction: () -> Void)
+}

--- a/Solply/Solply/Global/Modifier/CustomNavigationBarModifier.swift
+++ b/Solply/Solply/Global/Modifier/CustomNavigationBarModifier.swift
@@ -17,7 +17,7 @@ struct CustomNavigationBarModifier<C, L, R>: ViewModifier where C: View, L: View
         centerView: (() -> C)? = nil,
         leftView: (() -> L)? = nil,
         rightView: (() -> R)? = nil,
-        backgroundColor: Color = .clear
+        backgroundColor: Color = .coreWhite
     ) {
         self.centerView = centerView
         self.leftView = leftView
@@ -39,10 +39,8 @@ struct CustomNavigationBarModifier<C, L, R>: ViewModifier where C: View, L: View
                 self.centerView?()
                 
             }
-            
-            // TODO: 네비게이션 패딩값 나오면 수정 필요
-            .padding(.horizontal, 0)
-            .padding(.vertical, 0)
+            .padding(.horizontal, 16.adjustedWidth)
+            .padding(.vertical, 16.adjustedHeight)
             .background(backgroundColor)
             
             content
@@ -50,5 +48,190 @@ struct CustomNavigationBarModifier<C, L, R>: ViewModifier where C: View, L: View
             Spacer()
         }
         .navigationBarHidden(true)
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func customNavigationBar(_ navigationBarType: NavigationBarType) -> some View {
+        switch navigationBarType {
+        case .onboarding(let backAction):
+            self.modifier(
+                CustomNavigationBarModifier(
+                    centerView: {
+                        EmptyView()
+                    },
+                    leftView: {
+                        Button {
+                            backAction()
+                        } label: {
+                            Image(.backIconIos)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                        }
+                        .buttonStyle(.plain)
+                    },
+                    rightView: {
+                        EmptyView()
+                    }
+                )
+            )
+            
+        case .recommend(let filterTitle, let filterAction, let settingAction):
+            self.modifier(
+                CustomNavigationBarModifier(
+                    centerView: {
+                        EmptyView()
+                    },
+                    leftView: {
+                        HStack(alignment: .center, spacing: 4.adjustedWidth) {
+                            Image(.townIcon)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                            
+                            Button {
+                                filterAction()
+                            } label: {
+                                HStack(alignment: .center, spacing: 4.adjustedWidth) {
+                                    Text(filterTitle)
+                                        .applySolplyFont(.body_16_m)
+                                    
+                                    Image(.arrowRightIcon)
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                                }
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    },
+                    rightView: {
+                        Button {
+                            settingAction()
+                        } label: {
+                            Image(.settingIcon)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                )
+            )
+            
+        case .placeDetail(let title, let backAction, let homeAction):
+            self.modifier(
+                CustomNavigationBarModifier(
+                    centerView: {
+                        Text(title)
+                            .applySolplyFont(.head_16_m)
+                    },
+                    leftView: {
+                        Button {
+                            backAction()
+                        } label: {
+                            Image(.backIconIos)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                        }
+                        .buttonStyle(.plain)
+                    },
+                    rightView: {
+                        Button {
+                            homeAction()
+                        } label: {
+                            Image(.homeIcon)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                )
+            )
+            
+        case .courseDetail(let backAction, let homeAction):
+            self.modifier(
+                CustomNavigationBarModifier(
+                    centerView: {
+                        Text("코스 상세보기")
+                            .applySolplyFont(.head_16_m)
+                    },
+                    leftView: {
+                        Button {
+                            backAction()
+                        } label: {
+                            Image(.backIconIos)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                        }
+                        .buttonStyle(.plain)
+                    },
+                    rightView: {
+                        Button {
+                            homeAction()
+                        } label: {
+                            Image(.homeIcon)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                )
+            )
+            
+        case .archive(let backAction):
+            self.modifier(
+                CustomNavigationBarModifier(
+                    centerView: {
+                        Text("수집함")
+                            .applySolplyFont(.head_16_m)
+                    },
+                    leftView: {
+                        Button {
+                            backAction()
+                        } label: {
+                            Image(.backIconIos)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                        }
+                        .buttonStyle(.plain)
+                    },
+                    rightView: {
+                        EmptyView()
+                    }
+                )
+            )
+            
+        case .archiveList(let title, let backAction):
+            self.modifier(
+                CustomNavigationBarModifier(
+                    centerView: {
+                        Text(title)
+                            .applySolplyFont(.head_16_m)
+                    },
+                    leftView: {
+                        Button {
+                            backAction()
+                        } label: {
+                            Image(.backIconIos)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                        }
+                        .buttonStyle(.plain)
+                    },
+                    rightView: {
+                        EmptyView()
+                    }
+                )
+            )
+        }
     }
 }


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 커스텀 네비바를 구현했습니다.
- 네비바 타입에 따라 다르게 보이게 했어요

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| 네비바 모임 | <img src = "https://github.com/user-attachments/assets/7e60c388-a463-4560-b85b-de615083647e" width ="250"> | <img src = "https://github.com/user-attachments/assets/51428e9b-8d28-4c3e-bcf7-1daf61344d9b" width ="250"> |


## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 커스텀 네비바 사용하는 방법
```Swift
/// 네비게이션 바 타입입니다.
enum NavigationBarType {
    case onboarding(backAction: () -> Void)
    case recommend(filterTitle: String, filterAction: () -> Void, settingAction: () -> Void)
    case placeDetail(title: String, backAction: () -> Void, homeAction: () -> Void)
    case courseDetail(backAction: () -> Void, homeAction: () -> Void)
    case archive(backAction: () -> Void)
    case archiveList(title: String, backAction: () -> Void)
}
```
각자 사용해야하는 네비바 가져다 쓰시면 됩니다!

```Swift
.customNavigationBar(.archiveList(title: "장소 이름", backAction: appCoordinator.goBack))
```
그리고 appCoordinator를 사용해야하는 경우에는 바로 클로저 인자값으로 넣어주시면 됩니다!


## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #19 
