### PR TITLE
[feat/#28] 동네 선택 컴포넌트 구현

### DIFF
--- a/Solply/Solply/Global/Component/TownOptionButton.swift
+++ b/Solply/Solply/Global/Component/TownOptionButton.swift
@@ -49,16 +49,18 @@ struct TownOptionButton: View {
                     .foregroundColor(.gray900)
             } else {
                 Image(.plusIcon)
+                    .resizable()
+                    .renderingMode(.template)
+                    .aspectRatio(contentMode: .fit)
                     .foregroundColor(.gray400)
+                    .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
             }
         }
-        .padding(.horizontal, 15)
-        .padding(.vertical, 23)
-        .frame(width: 100, height: 100)
+        .frame(width: 100.adjustedWidth, height: 100.adjustedHeight)
         .background(type.backgroundColor(isSelected: isSelected))
         .capsuleClipped()
         .overlay(
-            RoundedRectangle(cornerRadius: 999)
+            Circle()
                 .stroke(type.borderColor(isSelected: isSelected), lineWidth: 1)
         )
     }

--- a/Solply/Solply/Global/Component/TownOptionButton.swift
+++ b/Solply/Solply/Global/Component/TownOptionButton.swift
@@ -11,18 +11,18 @@ struct TownOptionButton: View {
 
     // MARK: - Properties
     
-    let style: Style
-    let isSelected: Bool
-    let action: (() -> Void)?
+    private let type: TownOptionButtonType
+    private let isSelected: Bool
+    private let action: (() -> Void)?
 
     // MARK: - Initializer
     
     init(
-        style: Style,
+        type: TownOptionButtonType,
         isSelected: Bool = false,
         action: (() -> Void)? = nil
     ) {
-        self.style = style
+        self.type = type
         self.isSelected = isSelected
         self.action = action
     }
@@ -31,7 +31,9 @@ struct TownOptionButton: View {
     
     var body: some View {
         if let action = action {
-            Button(action: action) {
+            Button {
+                action()
+            } label: {
                 content
             }
         } else {
@@ -40,59 +42,59 @@ struct TownOptionButton: View {
     }
 
     private var content: some View {
-        VStack(spacing: 10) {
-            if let title = style.title {
+        VStack(alignment: .leading, spacing: 10) {
+            if let title = type.title {
                 Text(title)
                     .applySolplyFont(.button_16_m)
                     .foregroundColor(.gray900)
             } else {
-                Image("plus-icon")
-                    .foregroundColor(.secondary)
+                Image(.plusIcon)
+                    .foregroundColor(.gray400)
             }
         }
         .padding(.horizontal, 15)
         .padding(.vertical, 23)
         .frame(width: 100, height: 100)
-        .background(style.backgroundColor(isSelected: isSelected))
-        .cornerRadius(999)
+        .background(type.backgroundColor(isSelected: isSelected))
+        .capsuleClipped()
         .overlay(
             RoundedRectangle(cornerRadius: 999)
-                .stroke(style.borderColor(isSelected: isSelected), lineWidth: 1)
+                .stroke(type.borderColor(isSelected: isSelected), lineWidth: 1)
         )
     }
 }
 
-// MARK: - Style
+// MARK: - Type
 
 extension TownOptionButton {
-    enum Style {
-        case mangwon
-        case yeonhui
-        case add
+    enum TownOptionButtonType {
+            case named(String)
+            case add
 
         var title: String? {
             switch self {
-            case .mangwon: return "망원동"
-            case .yeonhui: return "연희동"
-            case .add:     return nil
+            case .named(let name):
+                return name
+            case .add:
+                return nil
             }
         }
 
         func backgroundColor(isSelected: Bool) -> Color {
             switch self {
-            case .mangwon, .yeonhui:
-                return isSelected ? Color("gray-100") : Color("red-100")
+            case .named:
+                return isSelected ? .gray100 : .red100
             case .add:
-                return Color("gray-200")
+                return .gray200
             }
         }
 
         func borderColor(isSelected: Bool) -> Color {
             switch self {
-            case .mangwon, .yeonhui:
-                return isSelected ? Color("gray-300") : Color("red-300")
+            case .named:
+                return isSelected ? .gray300 : .red300
             case .add:
-                return Color("gray-200")
+                return .gray200
             }
         }
     }

--- a/Solply/Solply/Global/Component/TownOptionButton.swift
+++ b/Solply/Solply/Global/Component/TownOptionButton.swift
@@ -42,7 +42,7 @@ struct TownOptionButton: View {
     }
 
     private var content: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: 10.adjustedWidth) {
             if let title = type.title {
                 Text(title)
                     .applySolplyFont(.button_16_m)

--- a/Solply/Solply/Global/Component/TownOptionButton.swift
+++ b/Solply/Solply/Global/Component/TownOptionButton.swift
@@ -1,0 +1,99 @@
+//
+//  TownOptionButton.swift
+//  Solply
+//
+//  Created by 선영주 on 7/8/25.
+//
+
+import SwiftUI
+
+struct TownOptionButton: View {
+
+    // MARK: - Properties
+    
+    let style: Style
+    let isSelected: Bool
+    let action: (() -> Void)?
+
+    // MARK: - Initializer
+    
+    init(
+        style: Style,
+        isSelected: Bool = false,
+        action: (() -> Void)? = nil
+    ) {
+        self.style = style
+        self.isSelected = isSelected
+        self.action = action
+    }
+
+    // MARK: - Body
+    
+    var body: some View {
+        if let action = action {
+            Button(action: action) {
+                content
+            }
+        } else {
+            content
+        }
+    }
+
+    private var content: some View {
+        VStack(spacing: 10) {
+            if let title = style.title {
+                Text(title)
+                    .applySolplyFont(.button_16_m)
+                    .foregroundColor(.gray900)
+            } else {
+                Image("plus-icon")
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(.horizontal, 15)
+        .padding(.vertical, 23)
+        .frame(width: 100, height: 100)
+        .background(style.backgroundColor(isSelected: isSelected))
+        .cornerRadius(999)
+        .overlay(
+            RoundedRectangle(cornerRadius: 999)
+                .stroke(style.borderColor(isSelected: isSelected), lineWidth: 1)
+        )
+    }
+}
+
+// MARK: - Style
+
+extension TownOptionButton {
+    enum Style {
+        case mangwon
+        case yeonhui
+        case add
+
+        var title: String? {
+            switch self {
+            case .mangwon: return "망원동"
+            case .yeonhui: return "연희동"
+            case .add:     return nil
+            }
+        }
+
+        func backgroundColor(isSelected: Bool) -> Color {
+            switch self {
+            case .mangwon, .yeonhui:
+                return isSelected ? Color("gray-100") : Color("red-100")
+            case .add:
+                return Color("gray-200")
+            }
+        }
+
+        func borderColor(isSelected: Bool) -> Color {
+            switch self {
+            case .mangwon, .yeonhui:
+                return isSelected ? Color("gray-300") : Color("red-300")
+            case .add:
+                return Color("gray-200")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->

|    구현 내용    |   선택 X   |   망원동 선택   | 연희동 선택  |
| :-------------: | :----------: | :----------: | :----------: |
| 컴포넌트 | <img src = "https://github.com/user-attachments/assets/c0fed227-1027-44da-af6a-e9f669d78d68" width ="250"> | <img src = "https://github.com/user-attachments/assets/d18cc105-fef4-4a09-826c-c889ecc7d66e" width ="250"> | <img src = "https://github.com/user-attachments/assets/1c9acd89-7427-4f4c-8b89-1f41e8d25f97" width ="250"> |



## 💻 주요 코드 설명

### 사용법
```Swift
HStack(spacing: 24) {
        TownOptionButton(style: .mangwon) {
        }
        TownOptionButton(style: .yeonhui) {
        }
        TownOptionButton(style: .add) {
        }
    }
    .padding()
}
```
- 대충 이러코롬 쓰시면 됩니다 (크기 안잡아둬서 알아서 조정댐)

## 📚 참고자료
교수님의 `SolplySaveButton`, `SolplyAddButton` 훔쳐봄