### PR TITLE
[feat/#42] 코스 공통 컴포넌트 구현

### DIFF
--- a/Solply/Solply/Global/Component/CourseCard.swift
+++ b/Solply/Solply/Global/Component/CourseCard.swift
@@ -1,0 +1,72 @@
+//
+//  CourseCard.swift
+//  Solply
+//
+//  Created by LEESOOYONG on 7/8/25.
+//
+
+import SwiftUI
+
+struct CourseCard: View {
+    
+    // MARK: - Properties
+    
+    private let isSaved: Bool
+    private let title: String
+    private let courseCategory: [PlaceCategoryType]
+    
+    // MARK: - Initializer
+    
+    init(isSaved: Bool, title: String, courseCategory: [PlaceCategoryType]) {
+        self.isSaved = isSaved
+        self.title = title
+        self.courseCategory = courseCategory
+    }
+    
+    // MARK: - Body
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            Image(.place)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 165.adjustedWidth, height: 165.adjustedHeight)
+                .cornerRadius(20, corners: .allCorners)
+            
+            VStack(alignment: .leading, spacing: 12.adjustedHeight) {
+                HStack(alignment: .center) {
+                    Text(title)
+                        .applySolplyFont(.title_14_m)
+                        .foregroundStyle(.coreBlack)
+                        .frame(height: 36.adjustedHeight)
+                    
+                    Spacer()
+                    
+                    if isSaved, let isSavedBadge = courseCategory.first?.savedBadge {
+                        Image(isSavedBadge)
+                            .aspectRatio(contentMode: .fit)
+                    }
+                }
+                .padding(.top, 8.adjustedHeight)
+                .padding(.horizontal, 12.adjustedWidth)
+                
+                HStack(alignment: .center, spacing: 4.adjustedWidth) {
+                    ForEach(courseCategory.prefix(2), id: \.self) { category in
+                        PlaceCategoryTag(placeCategory: category)
+                            .frame(height: 20.adjustedHeight)
+                    }
+                }
+                .padding(.bottom, 12.adjustedHeight)
+                .padding(.leading, 12.adjustedWidth)
+            }
+            .frame(width: 165.adjustedWidth ,height: 88.adjustedHeight)
+            .background(courseCategory.first?.courseBackgroundColor)
+            .cornerRadius(4, corners: [.topLeft, .topRight])
+            .cornerRadius(20, corners: [.bottomLeft, .bottomRight])
+        }
+    }
+}
+
+#Preview {
+    CourseCard(isSaved: true, title: "오감으로 수집하는 하루", courseCategory: [.food, .unique])
+}

--- a/Solply/Solply/Global/Component/PlaceCategoryTag.swift
+++ b/Solply/Solply/Global/Component/PlaceCategoryTag.swift
@@ -26,7 +26,7 @@ struct PlaceCategoryTag: View {
             .applySolplyFont(.body_14_m)
             .foregroundStyle(placeCategory.titleColor ?? .coreWhite)
             .padding(.horizontal, 8.adjustedWidth)
-            .padding(.vertical, 4.adjustedHeight)
+            .padding(.vertical, 1.adjustedHeight)
             .background(placeCategory.backgroundColor)
             .capsuleClipped()
     }

--- a/Solply/Solply/Global/Enum/PlaceCategoryType.swift
+++ b/Solply/Solply/Global/Enum/PlaceCategoryType.swift
@@ -63,4 +63,16 @@ enum PlaceCategoryType {
         case .unique: return "save-icon-green"
         }
     }
+    
+    var courseBackgroundColor: Color? {
+        switch self {
+        case .all: return nil
+        case .cafe: return .red300
+        case .food: return .yellow200
+        case .book: return .purple300
+        case .shopping: return .purple300
+        case .walk: return .green300
+        case .unique: return .green300
+        }
+    }
 }


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 코스 부분 공통 컴포넌트 구현

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| 코스 공통 컴포넌트 | <img src = "https://github.com/user-attachments/assets/5ccd8513-7cac-4b91-89d4-e6a82ee32e3a" width ="250"> | <img src = "https://github.com/user-attachments/assets/76cdf55e-0794-44cc-91a0-83e0915eb067" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 코스 공통 컴포넌트 배경 추가
```Swift
var courseBackgroundColor: Color? {
        switch self {
        case .all: return nil
        case .cafe: return .red300
        case .food: return .yellow200
        case .book: return .purple300
        case .shopping: return .purple300
        case .walk: return .green300
        case .unique: return .green300
        }
    }
```
enum을 사용해서 case에 따라서 공통 컴포넌트의 배경색을 지정했습니다.

### 코스 공통 컴포넌트 태그 2개 설정
```Swift
if isSaved, let isSavedBadge = courseCategory.first?.savedBadge {
                        Image(isSavedBadge)
                            .aspectRatio(contentMode: .fit)
                    }
                }
                .padding(.top, 8.adjustedHeight)
                .padding(.horizontal, 12.adjustedWidth)
                
                HStack(alignment: .center, spacing: 4.adjustedWidth) {
                    ForEach(courseCategory.prefix(2), id: \.self) { category in
                        PlaceCategoryTag(placeCategory: category)
                            .frame(height: 20.adjustedHeight)
                    }
                }
                .padding(.bottom, 12.adjustedHeight)
                .padding(.leading, 12.adjustedWidth)
            }
```
배열과 prefix를 사용하여 태그를 최대 2개까지 받을 수 있도록 설정하였습니다.

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #42 
