### PR TITLE
[feat/#56] 코스 상세 분기 처리 구현

### DIFF
--- a/Solply/Solply/Global/Component/NaverMap/CourseDetailMapView.swift
+++ b/Solply/Solply/Global/Component/NaverMap/CourseDetailMapView.swift
@@ -98,7 +98,7 @@ extension CourseDetailMapView {
         
         DispatchQueue.main.async {
             let cameraUpdate = NMFCameraUpdate(scrollTo: centerCoordinate, zoomTo: self.defaultZoomLevel)
-            cameraUpdate.animation = .easeOut
+            cameraUpdate.animation = .none
             mapView.moveCamera(cameraUpdate)
         }
     }
@@ -110,7 +110,7 @@ extension CourseDetailMapView {
         
         DispatchQueue.main.async {
             let cameraUpdate = NMFCameraUpdate(scrollTo: centerCoordinate, zoomTo: calculatedZoomLevel)
-            cameraUpdate.animation = .easeIn
+            cameraUpdate.animation = .fly
             mapView.moveCamera(cameraUpdate)
         }
     }

--- a/Solply/Solply/Global/Coordinator/Destination/AppDestination.swift
+++ b/Solply/Solply/Global/Coordinator/Destination/AppDestination.swift
@@ -7,10 +7,10 @@
 
 import SwiftUI
 
-enum AppDestination {
+enum AppDestination: Hashable {
     case archive
     case placeDetail
-    case courseDetail
+    case courseDetail(fromArchive: Bool)
 }
 
 extension AppDestination {
@@ -21,8 +21,8 @@ extension AppDestination {
             ArchiveView()
         case .placeDetail:
             PlaceDetailView()
-        case .courseDetail:
-            CourseDetailView()
+        case .courseDetail(let fromArchive):
+            CourseDetailView(fromeArchive: fromArchive)
         }
     }
 }

--- a/Solply/Solply/Global/Coordinator/Destination/RootDestination.swift
+++ b/Solply/Solply/Global/Coordinator/Destination/RootDestination.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-enum RootDestination {
+enum RootDestination: Hashable {
     case auth
     case onboarding
     case tabBar

--- a/Solply/Solply/Global/DesignSystem/Assets.xcassets/Image-icon/drag-drop-icon.imageset/Contents.json
+++ b/Solply/Solply/Global/DesignSystem/Assets.xcassets/Image-icon/drag-drop-icon.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "drag-drop-icon.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Solply/Solply/Global/DesignSystem/Assets.xcassets/Image-icon/drag-drop-icon.imageset/drag-drop-icon.svg
+++ b/Solply/Solply/Global/DesignSystem/Assets.xcassets/Image-icon/drag-drop-icon.imageset/drag-drop-icon.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 7H18" stroke="#D1CACD" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M6 12H18" stroke="#D1CACD" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M6 17H18" stroke="#D1CACD" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/Solply/Solply/Global/DesignSystem/Assets.xcassets/Image-icon/edit-done-icon.imageset/Contents.json
+++ b/Solply/Solply/Global/DesignSystem/Assets.xcassets/Image-icon/edit-done-icon.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "edit-done-icon.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Solply/Solply/Global/DesignSystem/Assets.xcassets/Image-icon/edit-done-icon.imageset/edit-done-icon.svg
+++ b/Solply/Solply/Global/DesignSystem/Assets.xcassets/Image-icon/edit-done-icon.imageset/edit-done-icon.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 11.2778L11.3333 18L20 7" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Solply/Solply/Presentation/Course/Component/DraggablePlaceCell.swift
+++ b/Solply/Solply/Presentation/Course/Component/DraggablePlaceCell.swift
@@ -17,6 +17,7 @@ struct DraggablePlaceCell: View {
     private let address: String
     private let isSaved: Bool
     private let isFocused: Bool
+    private let isEditing: Bool
     private let saveAction: (() -> Void)?
     private let detailAction: (() -> Void)?
     private let findDirectionAction: (() -> Void)?
@@ -31,6 +32,7 @@ struct DraggablePlaceCell: View {
         address: String,
         isSaved: Bool,
         isFocused: Bool,
+        isEditing: Bool,
         tapAction: (() -> Void)?,
         detailAction: (() -> Void)?,
         findDirectionAction: (() -> Void)?,
@@ -43,6 +45,7 @@ struct DraggablePlaceCell: View {
         self.saveAction = saveAction
         self.isSaved = isSaved
         self.isFocused = isFocused
+        self.isEditing = isEditing
         self.detailAction = detailAction
         self.findDirectionAction = findDirectionAction
         self.tapAction = tapAction
@@ -81,14 +84,22 @@ struct DraggablePlaceCell: View {
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     
-                    Button {
-                        saveAction?()
-                    } label: {
-                        Image(isSaved ? .saveIconRed : .saveIconGray)
+                    if isEditing {
+                        Image(.dragDropIcon)
                             .resizable()
+                            .aspectRatio(contentMode: .fit)
                             .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                        
+                    } else {
+                        Button {
+                            saveAction?()
+                        } label: {
+                            Image(isSaved ? .saveIconRed : .saveIconGray)
+                                .resizable()
+                                .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                        }
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
                 }
                 .padding(.top, 4.adjustedHeight)
                 
@@ -112,8 +123,10 @@ struct DraggablePlaceCell: View {
         .cornerRadius(20, corners: .allCorners)
         .addBorder(.roundedRectangle(cornerRaius: 20), borderColor: .gray300, borderWidth: 1)
         .onTapGesture {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                tapAction?()
+            if !isEditing {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    tapAction?()
+                }
             }
         }
     }

--- a/Solply/Solply/Presentation/Course/CourseDetail/Intent/CourseDetailAction.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/Intent/CourseDetailAction.swift
@@ -11,6 +11,7 @@ enum CourseDetailAction {
     case toggleSaveCourse
     case focusPlace(index: Int)
     case toggleSavePlace(index: Int)
+    case toggleEdting
     
     case fetchCourseDetailData
     case courseDetailDataFetched(Course)

--- a/Solply/Solply/Presentation/Course/CourseDetail/State/CourseDetailReducer.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/State/CourseDetailReducer.swift
@@ -31,6 +31,15 @@ enum CourseDetailReducer {
             
         case .toggleSavePlace(let index):
             state.places[index].isSaved.toggle()
+            
+        case .toggleEdting:
+            state.isEditing.toggle()
+            state.focusedPlaceIndex = -1
+            
+            for index in state.places.indices {
+                state.places[index].isFocused = false
+            }
+            
         }
     }
 }

--- a/Solply/Solply/Presentation/Course/CourseDetail/State/CourseDetailState.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/State/CourseDetailState.swift
@@ -13,6 +13,6 @@ struct CourseDetailState {
     var courseDescription: String = ""
     var places: [Place] = []
     var focusedPlaceIndex: Int = -1
-    
     var courseSaveSelected: Bool = false
+    var isEditing: Bool = false
 }

--- a/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
@@ -14,6 +14,14 @@ struct CourseDetailView: View {
     @EnvironmentObject var appCoordinator: AppCoordinator
     @StateObject private var store = CourseDetailStore()
     
+    private let fromeArchive: Bool
+    
+    // MARK: - Initializer
+    
+    init(fromeArchive: Bool) {
+        self.fromeArchive = fromeArchive
+    }
+    
     // MARK: - Body
     
     var body: some View {
@@ -25,7 +33,9 @@ struct CourseDetailView: View {
                 )
             )
             .detailBottomSheet {
-                bottomSheetTopButton
+                if !fromeArchive {
+                    bottomSheetTopButton
+                }
             } sheetContent: {
                 VStack(alignment: .center, spacing: 10.adjustedHeight) {
                     title
@@ -58,13 +68,35 @@ extension CourseDetailView {
     
     private var title: some View {
         VStack(alignment: .leading, spacing: 4.adjustedHeight) {
-            Text(store.state.courseTitle)
-                .applySolplyFont(.title_18_sb)
+            
+            Group {
+                if fromeArchive {
+                    HStack(alignment: .center, spacing: 4.adjustedWidth) {
+                        Text(store.state.courseTitle)
+                            .applySolplyFont(.title_18_sb)
+                            .frame(width: 307.adjustedWidth, alignment: .leading)
+                        
+                        Button {
+                            
+                        } label: {
+                            Image(.editingIcon)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                        }
+                    }
+                    
+                } else {
+                    Text(store.state.courseTitle)
+                        .applySolplyFont(.title_18_sb)
+                        .frame(width: 335.adjustedWidth, alignment: .leading)
+                }
+            }
+            .frame(height: 23.adjustedHeight)
             
             Text(store.state.courseDescription)
                 .applySolplyFont(.caption_14_r)
                 .frame(maxHeight: 21.adjustedHeight)
-                
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -103,8 +135,11 @@ extension CourseDetailView {
 }
 
 #Preview {
-    CourseDetailView()
+    CourseDetailView(fromeArchive: true)
         .environmentObject(AppCoordinator())
+    
+//    CourseDetailView(fromeArchive: false)
+//        .environmentObject(AppCoordinator())
 }
 
 // MARK: - 임시 모델
@@ -116,7 +151,7 @@ struct Course {
     
     static func mockData() -> Course {
         return Course(
-            courseTitle: "오감으로 수집하는 하루",
+            courseTitle: "오감으로 수집하는 하루우우우우우우우우우우우우우우우우우우우우우",
             courseDescription: "귀여운 당고 디저트와 커피, 에이드가 있는 펫 프렌들리 코스",
             places: [
                 Place(
@@ -126,8 +161,8 @@ struct Course {
                     isFocused: false,
                     isSaved: true,
                     placeCategoryType: .book,
-                    title: "장소 이름",
-                    address: "상세주소"
+                    title: "장소 이름응응응믕믕믕믕믕응으으으으",
+                    address: "상세주소오오오오오오오오오오오오오"
                 ),
                 Place(
                     imageURL: "",
@@ -135,7 +170,7 @@ struct Course {
                     longitude: 126.9239,
                     isFocused: false,
                     isSaved: false,
-                    placeCategoryType: .book,
+                    placeCategoryType: .unique,
                     title: "장소 이름",
                     address: "상세주소"
                 ),
@@ -145,7 +180,7 @@ struct Course {
                     longitude: 126.9253,
                     isFocused: false,
                     isSaved: true,
-                    placeCategoryType: .book,
+                    placeCategoryType: .cafe,
                     title: "장소 이름",
                     address: "상세주소"
                 ),
@@ -155,7 +190,7 @@ struct Course {
                     longitude: 126.9260,
                     isFocused: false,
                     isSaved: false,
-                    placeCategoryType: .book,
+                    placeCategoryType: .food,
                     title: "장소 이름",
                     address: "상세주소"
                 ),
@@ -165,7 +200,7 @@ struct Course {
                     longitude: 126.9235,
                     isFocused: false,
                     isSaved: false,
-                    placeCategoryType: .book,
+                    placeCategoryType: .shopping,
                     title: "장소 이름",
                     address: "상세주소"
                 ),

--- a/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
@@ -77,13 +77,16 @@ extension CourseDetailView {
                             .frame(width: 307.adjustedWidth, alignment: .leading)
                         
                         Button {
-                            
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                store.dispatch(.toggleEdting)
+                            }
                         } label: {
-                            Image(.editingIcon)
+                            Image(store.state.isEditing ? .editDoneIcon : .editingIcon)
                                 .resizable()
                                 .aspectRatio(contentMode: .fit)
                                 .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
                         }
+                        .buttonStyle(.plain)
                     }
                     
                 } else {
@@ -114,7 +117,8 @@ extension CourseDetailView {
                             title: place.title,
                             address: place.address,
                             isSaved: place.isSaved,
-                            isFocused: (store.state.focusedPlaceIndex == index)
+                            isFocused: (store.state.focusedPlaceIndex == index),
+                            isEditing: store.state.isEditing
                         ) {
                             store.dispatch(.focusPlace(index: index))
                         } detailAction: {

--- a/Solply/Solply/Presentation/Course/CourseRecommend/CourseRecommendView.swift
+++ b/Solply/Solply/Presentation/Course/CourseRecommend/CourseRecommendView.swift
@@ -17,9 +17,15 @@ struct CourseRecommendView: View {
                 Text("CourseRecommendView")
                 
                 Button {
-                    appCoordinator.navigate(to: .courseDetail)
+                    appCoordinator.navigate(to: .courseDetail(fromArchive: false))
                 } label: {
-                    Text("navigate to CourseDetailView")
+                    Text("코스 추천 -> 코스 상세")
+                }
+                
+                Button {
+                    appCoordinator.navigate(to: .courseDetail(fromArchive: true))
+                } label: {
+                    Text("수집함 -> 코스 상세")
                 }
             }
             .frame(height: 1000)

--- a/Solply/Solply/Presentation/Onboarding/Component/ProgressBar.swift
+++ b/Solply/Solply/Presentation/Onboarding/Component/ProgressBar.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ProgressBar: View {
+    @State private var rectangleSize: CGSize = .zero
     var step: OnboardingStep
     
     var body: some View {
@@ -18,11 +19,29 @@ struct ProgressBar: View {
                     .capsuleClipped()
                 
                 Rectangle()
-                    .frame(width: geometry.size.width * 0.90 * CGFloat(step.rawValue + 1) * 0.3)
+                    .sizeState(size: $rectangleSize)
+                    .frame(width: geometry.size.width * 0.95)
+                    .foregroundColor(.clear)
+                    .capsuleClipped()
+                
+                Rectangle()
+                    .frame(width: progressWidth(totalWidth: rectangleSize.width))
                     .foregroundStyle(.gray900)
                     .capsuleClipped()
             }
         }
         .frame(height: 10.adjustedWidth)
+    }
+}
+
+// MARK: - Functions
+
+extension ProgressBar {
+    private func progressWidth(totalWidth: CGFloat) -> CGFloat {
+        let totalSteps = Double(OnboardingStep.allCases.count)
+        let currentStep = Double(step.rawValue + 1)
+        let progress = currentStep / totalSteps
+        
+        return totalWidth * progress
     }
 }


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 코스 상세 분기처리를 구현했습니다.
- 수집함에서 진입했을 때 버튼 상태를 구현했습니다.

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| 코스 상세 분기  | <img src = "https://github.com/user-attachments/assets/ce014a86-a05c-40f9-9c80-5f4c8ffe98af" width ="250"> | <img src = "https://github.com/user-attachments/assets/fed75b3c-b440-4ba3-a8c0-10eb9410425c" width ="250"> |
| 수집함 분기 | <img src = "https://github.com/user-attachments/assets/00d1cf83-fdd9-487b-8fcb-6e23f88a5357" width ="250"> | <img src = "https://github.com/user-attachments/assets/953dce05-7931-4a6b-ab22-e2d3fb400a72" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 진입점에 따른 분기처리
```Swift
enum AppDestination: Hashable {
    case archive
    case placeDetail
    case courseDetail(fromArchive: Bool)
}

extension AppDestination {
    @ViewBuilder
    func build() -> some View {
        switch self {
        case .archive:
            ArchiveView()
        case .placeDetail:
            PlaceDetailView()
        case .courseDetail(let fromArchive):
            CourseDetailView(fromeArchive: fromArchive)
        }
    }
}
```
`CourseDetailView`에 진입할 때 `Bool` 변수 `fromeArchive`를 연관값으로 받게 수정하였습니다.

```Swift
appCoordinator.navigate(to: .courseDetail(fromArchive: false))
appCoordinator.navigate(to: .courseDetail(fromArchive: true))
```
`CourseRecommendView`에서 이동하면 `false`, `ArchiveListView`에서 이동하면 `true`값을 주입합니다.

```Swift
import SwiftUI

struct CourseDetailView: View {
    
    // MARK: - Properties
    
    @EnvironmentObject var appCoordinator: AppCoordinator
    @StateObject private var store = CourseDetailStore()
    
    private let fromeArchive: Bool
    
    // MARK: - Initializer
    
    init(fromeArchive: Bool) {
        self.fromeArchive = fromeArchive
    }
```
`Bool`값을 주입받아 `CourseDetailView` 내부에서 분기처리합니다!

### 수정 상태 구현
```Swift
struct CourseDetailState {
    // ...
    var isEditing: Bool = false //  추가
}
```
`CourseDetailState`에 `isEditing` 상태를 추가했습니다.

```Swift
case .toggleEdting:
    state.isEditing.toggle()
    state.focusedPlaceIndex = -1
    
    for index in state.places.indices {
        state.places[index].isFocused = false
    }
```
수정상태로 진입하면, 선택되어있는 셀이 취소 되어야하고, 마커도 모두 `default`로 바꿔야 합니다.
`Reducer` 에서 `focus`된 셀 `index`를 -1로 바꿔주고(모든 셀 `focus` 취소)
`places`에 `isFocused` 변수를 모두 `false`로 바꾸어 마커도 모두 원상태로 돌립니다.

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #56 

