### PR TITLE
[feat/#64] 타운옵션뷰 구현 

### DIFF
--- a/Solply/Solply/Global/Component/TownOptionButton.swift
+++ b/Solply/Solply/Global/Component/TownOptionButton.swift
@@ -11,14 +11,14 @@ struct TownOptionButton: View {
 
     // MARK: - Properties
     
-    private let type: TownOptionButtonType
+    private let type: TownOptionType
     private let isSelected: Bool
     private let action: (() -> Void)?
 
     // MARK: - Initializer
     
     init(
-        type: TownOptionButtonType,
+        type: TownOptionType,
         isSelected: Bool = false,
         action: (() -> Void)? = nil
     ) {
@@ -56,45 +56,6 @@ struct TownOptionButton: View {
         .frame(width: 100.adjustedWidth, height: 100.adjustedHeight)
         .background(type.backgroundColor(isSelected: isSelected))
         .capsuleClipped()
-        .overlay(
-            Circle()
-                .stroke(type.borderColor(isSelected: isSelected), lineWidth: 1)
-        )
-    }
-}
-
-// MARK: - Type
-
-extension TownOptionButton {
-    enum TownOptionButtonType {
-            case named(String)
-            case add
-
-        var title: String? {
-            switch self {
-            case .named(let name):
-                return name
-            case .add:
-                return nil
-            }
-        }
-
-        func backgroundColor(isSelected: Bool) -> Color {
-            switch self {
-            case .named:
-                return isSelected ? .gray100 : .red100
-            case .add:
-                return .gray200
-            }
-        }
-
-        func borderColor(isSelected: Bool) -> Color {
-            switch self {
-            case .named:
-                return isSelected ? .gray300 : .red300
-            case .add:
-                return .gray200
-            }
-        }
+        .addBorder(.circle, borderColor: type.borderColor(isSelected: isSelected), borderWidth: 1)
     }
 }

--- a/Solply/Solply/Global/Enum/TownOptionType.swift
+++ b/Solply/Solply/Global/Enum/TownOptionType.swift
@@ -1,0 +1,48 @@
+//
+//  TownOptionType.swift
+//  Solply
+//
+//  Created by 선영주 on 7/11/25.
+//
+
+import SwiftUI
+
+enum TownOptionType: Hashable, CaseIterable {
+    case named(String)
+    case add
+
+    static var allCases: [TownOptionType] {
+        return [
+            .named("망원동"),
+            .named("연희동"),
+            .add
+        ]
+    }
+
+    var title: String? {
+        switch self {
+        case .named(let name):
+            return name
+        case .add:
+            return nil
+        }
+    }
+
+    func backgroundColor(isSelected: Bool) -> Color {
+        switch self {
+        case .named:
+            return isSelected ? .red100 : .gray100
+        case .add:
+            return .gray200
+        }
+    }
+
+    func borderColor(isSelected: Bool) -> Color {
+        switch self {
+        case .named:
+            return isSelected ? .red300 : .gray300
+        case .add:
+            return .gray200
+        }
+    }
+}

--- a/Solply/Solply/Presentation/Onboarding/Component/NicknameView.swift
+++ b/Solply/Solply/Presentation/Onboarding/Component/NicknameView.swift
@@ -8,20 +8,27 @@
 import SwiftUI
 
 struct NicknameView: View {
+    
+    // TODO: - Rootview로 안가니까 지울거임
     @EnvironmentObject var appCoordinator: AppCoordinator
     @ObservedObject var store: OnboardingStore
 
     var body: some View {
-        VStack {
-            Text("")
-                .padding()
-
+        VStack(alignment: .leading, spacing: 0) {
+            
+            Text("솔플리와 함께할 준비 되셨나요?\n닉네임을 알려주세요.")
+                .applySolplyFont(.display_20_sb)
+                .foregroundStyle(.gray900)
+                .padding(.top, 24.adjustedHeight)
+                .padding(.bottom, 28.adjustedHeight)
+            
             Spacer()
-
+            
             CTAMainButton(title: "다음") {
                 appCoordinator.changeRoot(to: .tabBar)
             }
-            .padding(.bottom, 40)
+            .frame(maxWidth: .infinity)
+        }
+        .padding(.bottom, 20.adjustedHeight)
         }
     }
-}

--- a/Solply/Solply/Presentation/Onboarding/Component/PersonaOptionView.swift
+++ b/Solply/Solply/Presentation/Onboarding/Component/PersonaOptionView.swift
@@ -10,8 +10,6 @@ import SwiftUI
 struct PersonaOptionView: View {
     
     @ObservedObject var store: OnboardingStore
-    @State private var selectedIndex: Int? = nil
-    
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -47,9 +45,8 @@ struct PersonaOptionView: View {
                 }
                 .frame(maxWidth: .infinity)
             }
-            .padding(.bottom, 40.adjustedHeight)
+            .padding(.bottom, 20.adjustedHeight)
         }
-        .padding(.horizontal, 20.adjustedWidth)
         .background(Color.gray100)
     }
 }

--- a/Solply/Solply/Presentation/Onboarding/Component/TownOptionView.swift
+++ b/Solply/Solply/Presentation/Onboarding/Component/TownOptionView.swift
@@ -8,20 +8,37 @@
 import SwiftUI
 
 struct TownOptionView: View {
+    
     @ObservedObject var store: OnboardingStore
-
+    
     var body: some View {
-        VStack {
-            Spacer()
-            Text("타운 선택 화면")
-                .padding()
+        VStack(alignment: .leading, spacing: 0) {
+            
+            Text("반가워요!\n가장 먼저 추천 받고 싶은 동네를\n선택해주세요.")
+                .applySolplyFont(.display_20_sb)
+                .foregroundStyle(.gray900)
+                .padding(.top, 24.adjustedHeight)
+                .padding(.bottom, 28.adjustedHeight)
+            
+            HStack(spacing: 20.adjustedWidth) {
+                ForEach(TownOptionType.allCases, id: \.self) { type in
+                    TownOptionButton(
+                        type: type,
+                        isSelected: store.state.townOption == type
+                    ) {
+                        store.dispatch(.selectTown(type))
+                    }
+                }
+            }
+            .padding(.bottom, 32.adjustedHeight)
 
             Spacer()
-
+            
             CTAMainButton(title: "다음") {
                 store.dispatch(.next)
             }
-            .padding(.bottom, 40)
+            .frame(maxWidth: .infinity)
         }
+        .padding(.bottom, 20.adjustedHeight)
     }
 }

--- a/Solply/Solply/Presentation/Onboarding/Intent/OnboardingAction.swift
+++ b/Solply/Solply/Presentation/Onboarding/Intent/OnboardingAction.swift
@@ -12,5 +12,6 @@ enum OnboardingAction {
     case goBack
     case skip
     
+    case selectTown(TownOptionType)
     case selectPersona(PersonaType)
 }

--- a/Solply/Solply/Presentation/Onboarding/State/OnboardingReducer.swift
+++ b/Solply/Solply/Presentation/Onboarding/State/OnboardingReducer.swift
@@ -22,6 +22,9 @@ struct OnboardingReducer {
         case .skip:
             state.step = .nickName
             
+        case .selectTown(let town):
+            state.townOption = town
+            
         case .selectPersona(let persona):
             state.personaOption = persona
         }

--- a/Solply/Solply/Presentation/Onboarding/State/OnboardingState.swift
+++ b/Solply/Solply/Presentation/Onboarding/State/OnboardingState.swift
@@ -8,7 +8,7 @@
 struct OnboardingState {
     var step: OnboardingStep = .townOption
     
-    var townOption: String = ""
+    var townOption: TownOptionType? = nil
     var personaOption: PersonaType? = nil
     var nickname: String = ""
 }


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 타운옵션뷰 ui 구현
- 타운옵션뷰 MVI 구현

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| 타운옵션뷰 | <img src = "https://github.com/user-attachments/assets/4a971814-d8da-48bd-b483-2569a4cd934e" width ="250"> | <img src = "https://github.com/user-attachments/assets/3f7ce2be-b7f3-458f-9429-8cba17b8e982" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### Hashable, CaseIterable
```Swift
import SwiftUI

enum TownOptionType: Hashable, CaseIterable {
    case named(String)
    case add

    static var allCases: [TownOptionType] {
        return [
            .named("망원동"),
            .named("연희동"),
            .add
        ]
    }

    var title: String? {
        switch self {
        case .named(let name):
            return name
        case .add:
            return nil
        }
    }
```
- Hashable은 Set이나 Dictionary의 키로 사용할 수 있게 됩니다. == 비교와 hash(into:) 함수가 사용되어 두 값이 같은지 판단합니다.

- CaseIterable은 enum의 모든 케이스를 배열 형태로 순회할 수 있도록 도와주는 프로토콜입니다. 연관값(associated value)이 있는 경우에는 자동 생성이 되지 않기 때문에, 직접 allCases를 구현해야 한다고 합니다.

## 🔗 연결된 이슈
- Connected: #64 

