### PR TITLE
[feat/#68] 뒤로가기 제스처 추가

### DIFF
--- a/Solply/Solply/Global/Extension/UINavigationController+.swift
+++ b/Solply/Solply/Global/Extension/UINavigationController+.swift
@@ -1,0 +1,20 @@
+//
+//  UINavigationController+.swift
+//  Solply
+//
+//  Created by 김승원 on 7/12/25.
+//
+
+import UIKit
+
+extension UINavigationController: @retroactive UIGestureRecognizerDelegate {
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return viewControllers.count > 1
+    }
+}
+


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 뒤로가기 제스처를 구현했습니다

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| A 기능 | <img src = "https://github.com/user-attachments/assets/f4bac16b-57b6-46d2-bbb3-5f81b6c2de37" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 뒤로가기 구현
SwiftUI에서 커스텀 네비바를 구현하면 뒤로가기 제스처가 없어지더라고요
SwiftUI에서는 백 제스처를 직접 제어하는 방법이 아직 없다고 합니다. 그래서 UIKit에 UINavigationController를 extension으로 확장하여 사용한다고 합니다. 코드 줍줍해서 가져왔어요

```Swift
import UIKit

extension UINavigationController: @retroactive UIGestureRecognizerDelegate {
    override open func viewDidLoad() {
        super.viewDidLoad()
        interactivePopGestureRecognizer?.delegate = self
    }

    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
        return viewControllers.count > 1
    }
}
```

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #68 

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
https://phillip5094.tistory.com/168

