### PR TITLE
[feat/#76] 장소 컴포넌트 선택 기능 구현

### DIFF
--- a/Solply/Solply/Global/Component/PlaceCard.swift
+++ b/Solply/Solply/Global/Component/PlaceCard.swift
@@ -14,41 +14,57 @@ struct PlaceCard: View {
     private let isSaved: Bool
     private let title: String
     private let placeCategory: PlaceCategoryType
+    private let isSelected: Bool
+    private let action: (() -> Void)?
     
     // MARK: - Initializer
     
-    init(isSaved: Bool, title: String, placeCategory: PlaceCategoryType) {
+    init(
+        isSaved: Bool,
+        title: String,
+        placeCategory: PlaceCategoryType,
+        isSelected: Bool,
+        action: (() -> Void)? = nil
+    ) {
         self.isSaved = isSaved
         self.title = title
         self.placeCategory = placeCategory
+        self.isSelected = isSelected
+        self.action = action
     }
     
     // MARK: - Body
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8.adjustedHeight) {
-            ZStack(alignment: .bottomTrailing) {
-                Image(.place)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: 165.adjustedWidth, height: 165.adjustedHeight)
-                    .cornerRadius(20, corners: .allCorners)
-                
-                if isSaved {
-                    Image(placeCategory.savedBadge ?? "")
+        Button {
+            action?()
+        } label: {
+            VStack(alignment: .leading, spacing: 8.adjustedHeight) {
+                ZStack(alignment: .bottomTrailing) {
+                    Image(.place)
                         .resizable()
-                        .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
-                        .aspectRatio(contentMode: .fit)
-                        .padding(.horizontal, 12.adjustedWidth)
-                        .padding(.vertical, 12.adjustedHeight)
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: 165.adjustedWidth, height: 165.adjustedHeight)
+                        .cornerRadius(20, corners: .allCorners)
+                    
+                    if isSaved {
+                        Image(placeCategory.savedBadge ?? "")
+                            .resizable()
+                            .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                            .aspectRatio(contentMode: .fit)
+                            .padding(.horizontal, 12.adjustedWidth)
+                            .padding(.vertical, 12.adjustedHeight)
+                    }
+                }
+                
+                HStack(alignment: .center, spacing: 4.adjustedWidth) {
+                    PlaceCategoryTag(placeCategory: placeCategory)
+                    Text(title)
+                        .applySolplyFont(.body_14_m)
+                        .foregroundStyle(.coreBlack)
                 }
             }
-            HStack(alignment: .center, spacing: 4.adjustedWidth) {
-                PlaceCategoryTag(placeCategory: placeCategory)
-                Text(title)
-                    .applySolplyFont(.body_14_m)
-                    .foregroundStyle(.coreBlack)
-            }
         }
+        .buttonStyle(.plain)
     }
 }

--- a/Solply/Solply/Presentation/Archive/ArchiveList/State/ArchiveListReducer.swift
+++ b/Solply/Solply/Presentation/Archive/ArchiveList/State/ArchiveListReducer.swift
@@ -18,10 +18,11 @@ enum ArchiveListReducer {
             }
             
         case .toggleSelect:
-            state.activeDelete.toggle()
+            state.activeDelete = true
             
         case .toggleCancel:
             state.selectedIndex.removeAll()
+            state.activeDelete = false
         }
     }
 }

--- a/Solply/Solply/Presentation/Archive/ArchiveList/View/ArchiveListView.swift
+++ b/Solply/Solply/Presentation/Archive/ArchiveList/View/ArchiveListView.swift
@@ -57,7 +57,7 @@ struct ArchiveListView: View {
                 }
             }
             ZStack(alignment: .topTrailing) {
-                ArchiveListFullView(archiveCategory: .course, store: store)
+                ArchiveListFullView(archiveCategory: .place, store: store)
             }
         }
         .customNavigationBar(.archiveList(title: "망원동", backAction: appCoordinator.goBack))

--- a/Solply/Solply/Presentation/Archive/Component/ArchiveListFullView.swift
+++ b/Solply/Solply/Presentation/Archive/Component/ArchiveListFullView.swift
@@ -17,10 +17,12 @@ struct ArchiveListFullView: View {
     private let archiveCategory: SolplyContentType
     private let columns = [GridItem(.fixed(165.adjustedWidth)), GridItem(.fixed(165.adjustedWidth))]
     private let town: [String] = ["망원동", "연희동"]
-    private let title: [String] = ["오감으로 수집하는 하루", "오감자"]
+    private let placeTitle: [String] = ["유어마인드", "내마인드", "니마인드"]
+    private let courseTitle: [String] = ["오감으로 수집하는 하루", "오감자", "찍어먹는 오감자"]
     private let tags: [[PlaceCategoryType]] = [
         [.book, .food],
-        [.walk, .unique]
+        [.walk, .unique],
+        [.shopping, .unique]
     ]
     
     // MARK: - Initializers
@@ -35,7 +37,7 @@ struct ArchiveListFullView: View {
     var body: some View {
         ScrollView {
             LazyVGrid(columns: columns, spacing: 16.adjustedHeight) {
-                ForEach(Array(town.enumerated()), id: \.offset) { index, _ in
+                ForEach(Array(courseTitle.enumerated()), id: \.offset) { index, _ in
                     archiveCell(index: index)
                 }
             }
@@ -53,16 +55,27 @@ extension ArchiveListFullView {
             case .place:
                 PlaceCard(
                     isSaved: true,
-                    title: title[index],
-                    placeCategory: .book
-                )
+                    title: placeTitle[index],
+                    placeCategory: .book,
+                    isSelected: store.state.selectedIndex.contains(index)
+                ) {
+                    if store.state.activeDelete {
+                        print(index)
+                        store.dispatch(.toggleArchiveList(index: index))
+                    }
+                    
+                    if store.state.activeCancel {
+                        store.dispatch(.toggleArchiveList(index: index))
+                    }
+                }
                 .frame(width: 165.adjustedWidth, height: 165.adjustedHeight)
+                .padding(.bottom, 32.adjustedHeight)
                 
             case .course:
                 VStack(alignment: .leading, spacing: 8.adjustedHeight) {
                     CourseCard(
                         isSaved: true,
-                        title: title[index],
+                        title: courseTitle[index],
                         courseCategory: tags[index],
                         isSelected: store.state.selectedIndex.contains(index)
                     ) {


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 장소 컴포넌트 선택 기능 구현했습니다.

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| 장소 선택 기능 | ![Simulator Screen Recording - iPhone 13 mini - 2025-07-12 at 18 20 39](https://github.com/user-attachments/assets/c829135a-dbc9-4dbf-a6c2-dcfc9da47693) | ![Simulator Screen Recording - iPhone 16 Pro - 2025-07-12 at 18 21 41](https://github.com/user-attachments/assets/82855cce-71b7-4ed9-b5aa-00ed453548a2) |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### Reducer 수정
```Swift
case .toggleSelect:
    state.activeDelete = true
    
case .toggleCancel:
    state.selectedIndex.removeAll()
    state.activeDelete = false
}
```
toggle( )보다 확실하게 true, false 상태를 지정해주기 위해서 수정하였습니다.
취소 버튼을 누르게 되면 다시 선택이 뜨게 해야하기 때문에 activeDelete 상태를 false로 지정했습니다.

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #76 
