### PR TITLE
[feat/#78] custom alert 구현

### DIFF
--- a/Solply/Solply/Global/Enum/AlertType.swift
+++ b/Solply/Solply/Global/Enum/AlertType.swift
@@ -1,0 +1,20 @@
+//
+//  AlertType.swift
+//  Solply
+//
+//  Created by LEESOOYONG on 7/13/25.
+//
+
+import Foundation
+
+enum AlertType {
+    case delete
+    case leave
+
+    var mainText: String {
+        switch self {
+        case .delete: return "삭제"
+        case .leave: return "나가기"
+        }
+    }
+}

--- a/Solply/Solply/Global/Modifier/CustomAlertModifier.swift
+++ b/Solply/Solply/Global/Modifier/CustomAlertModifier.swift
@@ -1,0 +1,119 @@
+//
+//  CustomAlertModifier.swift
+//  Solply
+//
+//  Created by LEESOOYONG on 7/12/25.
+//
+
+import SwiftUI
+
+struct CustomAlertModifier: ViewModifier {
+    
+    // MARK: - Properties
+    
+    private let alertType: AlertType
+    private let title: String
+    private let isPresented: Bool
+    private let onCancel: (() -> Void)?
+    private let onConfirm: (() -> Void)?
+    
+    // MARK: - Initializers
+    
+    init(
+        alertType: AlertType,
+        title: String,
+        isPresented: Bool,
+        onCancel: (() -> Void)?,
+        onConfirm: (() -> Void)?
+    ) {
+        self.alertType = alertType
+        self.title = title
+        self.isPresented = isPresented
+        self.onCancel = onCancel
+        self.onConfirm = onConfirm
+    }
+    
+    // MARK: - Body
+    
+    func body(content: Content) -> some View {
+        content
+            .overlay(
+                Group {
+                    if isPresented {
+                        ZStack(alignment: .center) {
+                            Color.coreBlackO40
+                                .ignoresSafeArea()
+                            
+                            VStack(spacing: 8.adjustedHeight) {
+                                Text(title)
+                                    .applySolplyFont(.body_14_r)
+                                    .frame(width: 236.adjustedWidth, height: 65.adjustedHeight)
+                                    .multilineTextAlignment(.center)
+                                
+                                HStack(spacing: 12.adjustedWidth) {
+                                    Button {
+                                        onCancel?()
+                                    } label: {
+                                        Text("취소")
+                                            .applySolplyFont(.button_14_r)
+                                            .frame(width: 114.adjustedWidth, height: 48.adjustedHeight)
+                                            .foregroundStyle(.gray900)
+                                    }
+                                    
+                                    Button {
+                                        onConfirm?()
+                                    } label: {
+                                        Text(alertType.mainText)
+                                            .applySolplyFont(.button_14_r)
+                                            .frame(width: 122.adjustedWidth, height: 48.adjustedHeight)
+                                            .foregroundStyle(.coreWhite)
+                                            .background(.gray900)
+                                            .capsuleClipped()
+                                    }
+                                }
+                            }
+                            .frame(width: 260.adjustedWidth, height: 145.adjustedHeight)
+                            .padding(.vertical, 12.adjustedHeight)
+                            .padding(.horizontal, 12.adjustedWidth)
+                            .background(.coreWhite)
+                            .cornerRadius(12)
+                        }
+                    }
+                }
+            )
+    }
+}
+
+extension CustomAlertModifier {
+    enum AlertType {
+        case delete
+        case leave
+
+        var mainText: String {
+            switch self {
+            case .delete: return "삭제"
+            case .leave: return "나가기"
+            }
+        }
+    }
+}
+
+extension View {
+    func customAlert(
+        alertType: CustomAlertModifier.AlertType,
+        title: String,
+        isPresented: Bool,
+        onCancel: (() -> Void)?,
+        onConfirm: (() -> Void)?
+    ) -> some View {
+        self.modifier(
+            CustomAlertModifier(
+                alertType: alertType,
+                title: title,
+                isPresented: isPresented,
+                onCancel: onCancel,
+                onConfirm: onConfirm
+            )
+        )
+    }
+}

--- a/Solply/Solply/Global/Modifier/CustomAlertModifier.swift
+++ b/Solply/Solply/Global/Modifier/CustomAlertModifier.swift
@@ -84,23 +84,9 @@ struct CustomAlertModifier: ViewModifier {
     }
 }
 
-extension CustomAlertModifier {
-    enum AlertType {
-        case delete
-        case leave
-
-        var mainText: String {
-            switch self {
-            case .delete: return "삭제"
-            case .leave: return "나가기"
-            }
-        }
-    }
-}
-
 extension View {
     func customAlert(
-        alertType: CustomAlertModifier.AlertType,
+        alertType: AlertType,
         title: String,
         isPresented: Bool,
         onCancel: (() -> Void)?,

--- a/Solply/Solply/Presentation/Archive/ArchiveList/Intent/ArchiveListAction.swift
+++ b/Solply/Solply/Presentation/Archive/ArchiveList/Intent/ArchiveListAction.swift
@@ -11,4 +11,8 @@ enum ArchiveListAction {
     case toggleArchiveList(index: Int)
     case toggleSelect
     case toggleCancel
+    
+    case showAlert
+    case alertCancel
+    case alertDelete
 }

--- a/Solply/Solply/Presentation/Archive/ArchiveList/State/ArchiveListReducer.swift
+++ b/Solply/Solply/Presentation/Archive/ArchiveList/State/ArchiveListReducer.swift
@@ -23,6 +23,17 @@ enum ArchiveListReducer {
         case .toggleCancel:
             state.selectedIndex.removeAll()
             state.activeDelete = false
+            
+        case .showAlert:
+            state.isPresented = true
+            
+        case .alertCancel:
+            state.isPresented = false
+            
+        case .alertDelete:
+            state.isPresented = false
+            state.activeDelete = false
+            print("삭제 API 연결")
         }
     }
 }

--- a/Solply/Solply/Presentation/Archive/ArchiveList/State/ArchiveListState.swift
+++ b/Solply/Solply/Presentation/Archive/ArchiveList/State/ArchiveListState.swift
@@ -11,4 +11,6 @@ struct ArchiveListState {
     var selectedIndex: Set<Int> = []
     var activeDelete: Bool = false
     var activeCancel: Bool = false
+    
+    var isPresented: Bool = false
 }

--- a/Solply/Solply/Presentation/Archive/ArchiveList/View/ArchiveListView.swift
+++ b/Solply/Solply/Presentation/Archive/ArchiveList/View/ArchiveListView.swift
@@ -17,6 +17,7 @@ struct ArchiveListView: View {
     // MARK: - Body
     
     var body: some View {
+        
         VStack(alignment: .trailing, spacing: 16.adjustedHeight) {
             if store.state.activeDelete {
                 HStack {
@@ -33,7 +34,7 @@ struct ArchiveListView: View {
                     Spacer()
 
                     Button {
-                        // MARK: - 삭제 api 연결 예정
+                        store.dispatch(.showAlert)
                     } label: {
                         Text("삭제")
                             .applySolplyFont(.button_14_r)
@@ -57,10 +58,19 @@ struct ArchiveListView: View {
                 }
             }
             ZStack(alignment: .topTrailing) {
-                ArchiveListFullView(archiveCategory: .place, store: store)
+                ArchiveListFullView(archiveCategory: .course, store: store)
             }
         }
         .customNavigationBar(.archiveList(title: "망원동", backAction: appCoordinator.goBack))
+        .customAlert(
+            alertType: .delete,
+            title: "선택한 장소를 삭제할까요?",
+            isPresented: store.state.isPresented
+        ) {
+            store.dispatch(.alertCancel)
+        } onConfirm: {
+            store.dispatch(.alertDelete)
+        }
     }
 }
 


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- custom alert를 구현했습니다.

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| custom alert | ![Simulator Screen Recording - iPhone 13 mini - 2025-07-13 at 03 06 34](https://github.com/user-attachments/assets/8f1bd174-fc19-4bfd-a773-77601ed59964) | ![Simulator Screen Recording - iPhone 16 Pro - 2025-07-13 at 03 05 45](https://github.com/user-attachments/assets/b7da816c-5939-4496-bc14-21ca7bacd249) |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### custom alert modifier 구현
```Swift
extension CustomAlertModifier {
    enum AlertType {
        case delete
        case leave

        var mainText: String {
            switch self {
            case .delete: return "삭제"
            case .leave: return "나가기"
            }
        }
    }
}

extension View {
    func customAlert(
        alertType: CustomAlertModifier.AlertType,
        title: String,
        isPresented: Bool,
        onCancel: (() -> Void)?,
        onConfirm: (() -> Void)?
    ) -> some View {
        self.modifier(
            CustomAlertModifier(
                alertType: alertType,
                title: title,
                isPresented: isPresented,
                onCancel: onCancel,
                onConfirm: onConfirm
            )
        )
    }
}

```
alert에서 취소 버튼 외에 삭제, 나가기가 있어서 enum을 사용하여 분리하였습니다.

### alert MVI 적용
```Swift
case .showAlert:
    state.isPresented = true
    
case .alertCancel:
    state.isPresented = false
    
case .alertDelete:
    state.isPresented = false
    state.activeDelete = false
    print("삭제 API 연결")
```
alert창이 떴을 때, 취소 버튼을 눌렀을 때, 삭제 버튼을 눌렀을 때를 나눠서 구현하였습니다.
isPresented를 통해서 alert 창이 화면에 나타나는지를 관리했습니다.

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #78 
