### PR TITLE
[feat/#86] 코스 저장 navigate 구현

### DIFF
--- a/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
@@ -58,7 +58,7 @@ struct CourseDetailView: View {
             .onChange(of: store.state.toastContent) { _, toastContent in
                 guard let toastContent else { return }
                 toastManager.showToast(content: toastContent) {
-                    
+                    appCoordinator.navigate(to: .courseDetail(fromArchive: true))
                 }
             }
             .toast(toastManager: toastManager)
@@ -75,6 +75,17 @@ extension CourseDetailView {
             isSelected: store.state.courseSaveSelected
         ) {
             store.dispatch(.toggleSaveCourse)
+            if store.state.courseSaveSelected {
+                store.dispatch(
+                    .showToastView(
+                        ToastContent(
+                            toastType: .withActionToast,
+                            message: "코스가 수집함에 저장되었어요.",
+                            buttonTitle: "코스 수정하기"
+                        )
+                    )
+                )
+            }
         }
         .frame(maxWidth: .infinity, alignment: .trailing)
         .padding(.horizontal, 16.adjustedWidth)


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 코스 저장 후 토스트에서 navigate를 구현했어요

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| 토스트 후 navigate | <img src = "https://github.com/user-attachments/assets/0cd174cc-bced-4a58-8739-12e529154840" width ="250"> | <img src = "https://github.com/user-attachments/assets/721f93ff-63a7-4f23-9fb2-6a481738555d" width ="250"> |

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #86 

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 모두 파이팅!
