### PR TITLE
[feat/#121] 이니셜라이저 추가

### DIFF
--- a/Solply/Solply/Presentation/UsuallyTownOption/View/UsuallyTownOptionView.swift
+++ b/Solply/Solply/Presentation/UsuallyTownOption/View/UsuallyTownOptionView.swift
@@ -13,9 +13,21 @@ struct UsuallyTownOptionView: View {
     @EnvironmentObject private var appCoordinator: AppCoordinator
     @ObservedObject var store: UsuallyTownOptionStore
     
-    let initialTownOption: () -> TownOptionType
-    let confirmAction: (TownOptionType) -> Void
-    let backAction: () -> Void
+    private let selectedTownOption: () -> TownOptionType
+    private let confirmAction: (TownOptionType) -> Void
+    private let backAction: () -> Void
+    
+    init(
+        store: UsuallyTownOptionStore,
+        selectedTownOption: @escaping () -> TownOptionType,
+        confirmAction: @escaping (TownOptionType) -> Void,
+        backAction: @escaping () -> Void
+    ) {
+        self.store = store
+        self.selectedTownOption = selectedTownOption
+        self.confirmAction = confirmAction
+        self.backAction = backAction
+    }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -49,7 +61,7 @@ struct UsuallyTownOptionView: View {
             .padding(.bottom, 33.adjustedHeight)
         }
         .onAppear {
-            store.dispatch(.selectOption(initialTownOption()))
+            store.dispatch(.selectOption(selectedTownOption()))
         }
         .customNavigationBar(.archiveList(title: "자주 가는 동네", backAction: backAction))
         }
@@ -61,7 +73,7 @@ struct UsuallyTownOptionView: View {
 
     return UsuallyTownOptionView(
         store: store,
-        initialTownOption: { .named("망원동") },
+        selectedTownOption: { .named("망원동") },
         confirmAction: { selected in
             print("프리뷰: \(selected)")
         },


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 탭바에서 쓰일 `자주 가는 동네 옵션뷰` 구현

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| 버튼 선택되어 잇고, 선택도 잘댐 | <img src = "https://github.com/user-attachments/assets/1bf4d2d0-3a7a-47ad-a228-2cdbb2cd22c4" width ="250"> | <img src = "https://github.com/user-attachments/assets/030135a4-ff91-4584-8bfc-732d80260bbf" width ="250"> |
| 프린트 잘찍힘 | <img src = "https://github.com/user-attachments/assets/a8fba521-c290-4379-ab55-eca85292344c" width ="250"> | |

## 🔗 연결된 이슈
- Connected: #121