### PR TITLE
[feat/#150] 코스 상세 장소 단건 저장, 저장 취소 API 연동

### DIFF
--- a/Solply/Solply/Network/Service/PlaceService.swift
+++ b/Solply/Solply/Network/Service/PlaceService.swift
@@ -17,3 +17,18 @@ extension PlaceService {
     }
 }
 
+extension PlaceService {
+    func submitPlaceBookmark(
+        placeId: Int
+    ) async throws -> BaseResponseBody<EmptyResponseDTO> {
+        return try await self.request(with: .submitPlaceBookmark(placeId: placeId))
+    }
+}
+
+extension PlaceService {
+    func removePlaceBookmark(
+        placeId: Int
+    ) async throws -> BaseResponseBody<EmptyResponseDTO> {
+        return try await self.request(with: .removePlaceBookmark(placeId: placeId))
+    }
+}

--- a/Solply/Solply/Network/TargetType/PlaceTargetType.swift
+++ b/Solply/Solply/Network/TargetType/PlaceTargetType.swift
@@ -11,12 +11,16 @@ import Moya
 
 enum PlaceTargetType {
     case fetchPlaceThumbnail
+    case submitPlaceBookmark(placeId: Int)
+    case removePlaceBookmark(placeId: Int)
 }
 
 extension PlaceTargetType: BaseTargetType {
     var headerType: HTTPHeader {
         switch self {
         case .fetchPlaceThumbnail: return .accessToken
+        case .submitPlaceBookmark: return .accessToken
+        case .removePlaceBookmark: return .accessToken
         }
     }
     
@@ -24,18 +28,28 @@ extension PlaceTargetType: BaseTargetType {
         switch self {
         case .fetchPlaceThumbnail:
             return "/places/bookmarks/folders/preview"
+        case .submitPlaceBookmark(placeId: let placeId):
+            return "/places/\(placeId)/bookmarks"
+        case .removePlaceBookmark(placeId: let placeId):
+            return "/places/\(placeId)/bookmarks"
         }
     }
     
     var method: Moya.Method {
         switch self {
         case .fetchPlaceThumbnail: return .get
+        case .submitPlaceBookmark: return .post
+        case .removePlaceBookmark: return .delete
         }
     }
     
     var task: Moya.Task {
         switch self {
         case .fetchPlaceThumbnail:
+            return .requestPlain
+        case .submitPlaceBookmark:
+            return .requestPlain
+        case .removePlaceBookmark:
             return .requestPlain
         }
     }

--- a/Solply/Solply/Presentation/Course/CourseDetail/Effect/CourseDetailEffect.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/Effect/CourseDetailEffect.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct CourseDetailEffect {
     private let service = CourseService()
+    private let placeService = PlaceService()
     
     func fetchCourseDetail(courseId: Int) async -> CourseDetailAction {
         do {
@@ -45,6 +46,32 @@ struct CourseDetailEffect {
             let _ = try await service.removeCourseBookmark(courseId: courseId)
             
             return .courseBookmarkRemoved
+            
+        } catch let error as NetworkError {
+            return .errorOccured(error: error)
+        } catch {
+            return .errorOccured(error: .unknownError)
+        }
+    }
+    
+    func submitPlaceBookmark(placeId: Int) async -> CourseDetailAction {
+        do {
+            let _ = try await placeService.submitPlaceBookmark(placeId: placeId)
+            
+            return .placeBookmarkSubmited
+            
+        } catch let error as NetworkError {
+            return .errorOccured(error: error)
+        } catch {
+            return .errorOccured(error: .unknownError)
+        }
+    }
+    
+    func removePlaceBookmark(placeId: Int) async -> CourseDetailAction {
+        do {
+            let _ = try await placeService.removePlaceBookmark(placeId: placeId)
+            
+            return .placeBookmarkRemoved
             
         } catch let error as NetworkError {
             return .errorOccured(error: error)

--- a/Solply/Solply/Presentation/Course/CourseDetail/Intent/CourseDetailAction.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/Intent/CourseDetailAction.swift
@@ -40,4 +40,10 @@ enum CourseDetailAction {
     
     case removeCourseBookmark(courseId: Int)
     case courseBookmarkRemoved
+    
+    case submitPlaceBookmark(placeId: Int)
+    case placeBookmarkSubmited
+    
+    case removePlaceBookmark(placeId: Int)
+    case placeBookmarkRemoved
 }

--- a/Solply/Solply/Presentation/Course/CourseDetail/Intent/CourseDetailStore.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/Intent/CourseDetailStore.swift
@@ -34,6 +34,18 @@ final class CourseDetailStore: ObservableObject {
                 self.dispatch(result)
             }
             
+        case .submitPlaceBookmark(let placeId):
+            Task {
+                let result = await effect.submitPlaceBookmark(placeId: placeId)
+                self.dispatch(result)
+            }
+            
+        case .removePlaceBookmark(let placeId):
+            Task {
+                let result = await effect.removePlaceBookmark(placeId: placeId)
+                self.dispatch(result)
+            }
+            
         default:
             break
         }

--- a/Solply/Solply/Presentation/Course/CourseDetail/State/CourseDetailReducer.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/State/CourseDetailReducer.swift
@@ -128,6 +128,20 @@ enum CourseDetailReducer {
         case .courseBookmarkRemoved:
             print("저장 취소 완료")
             break
+            
+        case .submitPlaceBookmark:
+            break
+            
+        case .placeBookmarkSubmited:
+            print("장소 저장 완료")
+            break
+            
+        case .removePlaceBookmark:
+            break
+            
+        case .placeBookmarkRemoved:
+            print("장소 저장 취소 완료")
+            break
         }
     }
 }

--- a/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
@@ -183,6 +183,8 @@ extension CourseDetailView {
                     } saveAction: {
                         store.dispatch(.toggleSavePlace(index: index))
                         if store.state.places[index].isBookmarked {
+                            store.dispatch(.submitPlaceBookmark(placeId: store.state.places[index].placeId))
+                            
                             store.dispatch(
                                 .showToastView(
                                     ToastContent(
@@ -193,6 +195,8 @@ extension CourseDetailView {
                                 )
                             )
                         } else {
+                            store.dispatch(.removePlaceBookmark(placeId: store.state.places[index].placeId))
+                            
                             store.dispatch(
                                 .showToastView(
                                     ToastContent(


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 코스 상세에서 단건 장소 저장 및 취소 API를 구현했어요

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| 장소 저장 | <img src = "https://github.com/user-attachments/assets/3c813ec7-b6de-4eb9-81a2-46544ddf981e" width ="250"> |

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #150 

