### PR TITLE
[fix/#159] custom alert 1차 QA 반영

### DIFF
--- a/Solply/Solply/Global/Modifier/CustomAlertModifier.swift
+++ b/Solply/Solply/Global/Modifier/CustomAlertModifier.swift
@@ -50,7 +50,7 @@ struct CustomAlertModifier: ViewModifier {
                                     .frame(width: 236.adjustedWidth, height: 65.adjustedHeight)
                                     .multilineTextAlignment(.center)
                                 
-                                HStack(spacing: 12.adjustedWidth) {
+                                HStack(alignment: .center, spacing: 0.adjustedWidth) {
                                     Button {
                                         onCancel?()
                                     } label: {
@@ -73,8 +73,6 @@ struct CustomAlertModifier: ViewModifier {
                                 }
                             }
                             .frame(width: 260.adjustedWidth, height: 145.adjustedHeight)
-                            .padding(.vertical, 12.adjustedHeight)
-                            .padding(.horizontal, 12.adjustedWidth)
                             .background(.coreWhite)
                             .cornerRadius(12)
                         }


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- custom alert 1차 QA 진행했습니다.

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| custom alert QA | <img src = "https://github.com/user-attachments/assets/7e439811-19f7-4037-9e0d-ae3f28a105d1" width ="250"> | <img src = "https://github.com/user-attachments/assets/88e1287b-0b8d-46fd-aa47-e64fb38f5762" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### alert frame 지정
```Swift
.frame(width: 260.adjustedWidth, height: 145.adjustedHeight)
.background(.coreWhite)
.cornerRadius(12)
```
custom alert의 모든 부분에 frame을 지정해줬기 때문에 전체 frame에서 padding을 제거했습니다.

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #159 
