### PR TITLE
[feat/#167] aligned ScrollView 구현

### DIFF
--- a/Solply/Solply/Presentation/Place/Component/View/PlaceInformationView.swift
+++ b/Solply/Solply/Presentation/Place/Component/View/PlaceInformationView.swift
@@ -94,10 +94,10 @@ extension PlaceInformationView {
                         .cornerRadius(20, corners: .allCorners)
                 }
             }
-            .scrollTargetLayout() // 정렬 되어야 할 뷰 레이아웃에 붙여줍니다.
+            .scrollTargetLayout()
             .padding(.horizontal, 16.adjustedWidth)
         }
-        .scrollTargetBehavior(.viewAligned) // 스크롤 영역 가장자리에 콘텐츠 뷰가 딱 맞게 정렬됩니다.
+        .scrollTargetBehavior(.viewAligned)
     }
     
     private var information: some View {

--- a/Solply/Solply/Presentation/Place/Component/View/PlaceInformationView.swift
+++ b/Solply/Solply/Presentation/Place/Component/View/PlaceInformationView.swift
@@ -94,8 +94,10 @@ extension PlaceInformationView {
                         .cornerRadius(20, corners: .allCorners)
                 }
             }
+            .scrollTargetLayout() // 정렬 되어야 할 뷰 레이아웃에 붙여줍니다.
             .padding(.horizontal, 16.adjustedWidth)
         }
+        .scrollTargetBehavior(.viewAligned) // 스크롤 영역 가장자리에 콘텐츠 뷰가 딱 맞게 정렬됩니다.
     }
     
     private var information: some View {


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 생각보다 별 거 없엇다!

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| A 기능 | <img src = "https://github.com/user-attachments/assets/d7c122a9-a8b9-494e-a496-9462a949745f" width ="250"> |


## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 딱딱 붙는 스크롤 뷰
```Swift
private var mainImage: some View {
    ScrollView(.horizontal, showsIndicators: false) {
        HStack(alignment: .center, spacing: 12.adjustedWidth) {
            ForEach(imageURLs, id: \.self) { imageURL in
                KFImage(URL(string: imageURL))
                    .resizable()
                    .aspectRatio(contentMode: .fill)
                    .frame(width: UIScreen.main.bounds.width - 32.adjustedWidth, height:
                    .cornerRadius(20, corners: .allCorners)
            }
        }
        .scrollTargetLayout()  // 정렬 되어야 할 뷰 레이아웃에 붙여줍니다.
        .padding(.horizontal, 16.adjustedWidth)
    }
    .scrollTargetBehavior(.viewAligned) // 스크롤 영역 가장자리에 콘텐츠 뷰가 딱 맞게 정렬됩니다.
}
```
`ScrollViewReader`쓰고 막 어려울 줄 알았는데, 딸깍하면 되더라고요 굿!

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
https://devocean.sk.com/blog/techBoardDetail.do?ID=166937&boardType=techBlog

