### PR TITLE
[fix/#199] 장소 필터링 바텀시트 오류 수정

### DIFF
--- a/Solply/Solply/Presentation/Place/Component/FilterPlaceGrid.swift
+++ b/Solply/Solply/Presentation/Place/Component/FilterPlaceGrid.swift
@@ -52,6 +52,7 @@ struct FilterPlaceGrid: View {
             VStack(alignment: .leading, spacing: 16.adjustedHeight) {
                 HStack(alignment: .center, spacing: 8.adjustedWidth) {
                     FilterButton(title: mainTag.title) {
+                        store.dispatch(.updateMainTag)
                         store.dispatch(.toggleMainTagBottomSheet)
                     }
                     .sheet(
@@ -59,14 +60,20 @@ struct FilterPlaceGrid: View {
                             get: { store.state.isMainTagBottomSheetPresented },
                             set: { isPresented, selectedTag in
                                 if !isPresented {
-                                    store.dispatch(.resetSubTags)
-                                    store.dispatch(.fetchPlaceList(
-                                        townId: townId,
-                                        isBookmarkSearch: false,
-                                        mainTagId: store.state.selectedMainTag.parentId == 0 ? nil : store.state.selectedMainTag.parentId,
-                                        subTagAIdList: [],
-                                        subTagBIdList: []
-                                    ))
+                                    let current = store.state.selectedMainTag
+                                    let previous = store.state.previousMainTag
+                                    
+                                    if current != previous {
+                                        store.dispatch(.resetSubTags)
+                                        store.dispatch(.fetchPlaceList(
+                                            townId: townId,
+                                            isBookmarkSearch: false,
+                                            mainTagId: current.parentId == 0 ? nil : current.parentId,
+                                            subTagAIdList: [],
+                                            subTagBIdList: []
+                                        ))
+                                    }
+                                    
                                     store.dispatch(.dismissMainTagBottomSheet)
                                 }
                             }

--- a/Solply/Solply/Presentation/Place/PlaceRecommend/Intent/PlaceRecommendAction.swift
+++ b/Solply/Solply/Presentation/Place/PlaceRecommend/Intent/PlaceRecommendAction.swift
@@ -15,6 +15,7 @@ enum PlaceRecommendAction {
     case toggleSubTagBottomSheet
     case dismissSubTagBottomSheet
         
+    case updateMainTag
     case resetSubTags
     case updateSubTags([SelectableSubTag])
     

--- a/Solply/Solply/Presentation/Place/PlaceRecommend/State/PlaceRecommendReducer.swift
+++ b/Solply/Solply/Presentation/Place/PlaceRecommend/State/PlaceRecommendReducer.swift
@@ -22,6 +22,9 @@ struct PlaceRecommendReducer {
         case .dismissSubTagBottomSheet:
             state.isSubTagBottomSheetPresented = false
             
+        case .updateMainTag:
+            state.previousMainTag = state.selectedMainTag
+            
         case .resetSubTags:
             state.selectedSubTags.removeAll()
             

--- a/Solply/Solply/Presentation/Place/PlaceRecommend/State/PlaceRecommendState.swift
+++ b/Solply/Solply/Presentation/Place/PlaceRecommend/State/PlaceRecommendState.swift
@@ -13,6 +13,8 @@ struct PlaceRecommendState {
     var isMainTagBottomSheetPresented: Bool = false
     var isSubTagBottomSheetPresented: Bool = false
     
+    // 바텀 시트 닫힐 때 값이 변한 게 있는지 없는지, 뭘 선택을 했는지 판단하기 위한 state
+    var previousMainTag: MainTagType? = nil
     var selectedMainTag: MainTagType = .all
     var fetchedMainTags: [MainTag] = []
     var fetchedSubTags: [SubTag] = []


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 장소 필터링 바텀시트를 내릴 때마다 사용자의 선택이 초기화되는 오류를 수정했습니다.

|    구현 내용    |   iPhone 13 mini   | 
| :-------------: | :----------: |
| 장소 필터링 바텀시트 오류 수정 | <img src = "https://github.com/user-attachments/assets/3fc6931c-849a-4267-ad29-6b2d83d36b7b" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 오류 수정 방법
```Swift
    // PlaceRecommendState
    var previousMainTag: MainTagType? = nil
    var selectedMainTag: MainTagType = .all

    // FilterPlaceGrid
        ...
                    FilterButton(title: mainTag.title) {
                        store.dispatch(.updateMainTag)
                        store.dispatch(.toggleMainTagBottomSheet)
                    }
                    .sheet(
                        isPresented: Binding(
                            get: { store.state.isMainTagBottomSheetPresented },
                            set: { isPresented, selectedTag in
                                if !isPresented {
                                    let current = store.state.selectedMainTag
                                    let previous = store.state.previousMainTag
                                    
                                    if current != previous {
                                        store.dispatch(.resetSubTags)
                                        store.dispatch(.fetchPlaceList(
                                            townId: townId,
                                            isBookmarkSearch: false,
                                            mainTagId: current.parentId == 0 ? nil : current.parentId,
                                            subTagAIdList: [],
                                            subTagBIdList: []
                                        ))
                                    }
                                    
                                    store.dispatch(.dismissMainTagBottomSheet)
                                }
                            }
                        )
                    ) {
                        MainTagBottomSheet(
                            store: store,
                            isPresented: Binding(
                                get: { store.state.isMainTagBottomSheetPresented },
                                set: { isPresented in
                                    if !isPresented {
                                        store.dispatch(.dismissMainTagBottomSheet)
                                    }
                                }
                            )
                        )
                            .presentationDetents([.fraction(0.54)])
                    }
        ...

```
previousMainTag라는 이름의 사용자의 이전 선택을 저장할 변수를 state에 생성했습니다.
그리고 FilterPlaceGrid에서 시트를 닫을 때 previousMainTag와 selectedMainTag를 비교해 값이 달라진 경우에만 사용자의 선택을 초기화하도록 수정했습니다.

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #199 
