### PR TITLE
[refactor/#223] 수집함 custom alert 오타 수정

### DIFF
--- a/Solply/Solply/Presentation/Archive/ArchiveList/View/ArchiveListView.swift
+++ b/Solply/Solply/Presentation/Archive/ArchiveList/View/ArchiveListView.swift
@@ -82,7 +82,9 @@ struct ArchiveListView: View {
         }
         .customAlert(
             alertType: .delete,
-            title: "선택한 장소를 삭제할까요?",
+            title: archiveCategory == .place
+                    ? "선택한 장소를 삭제할까요?"
+                    : "선택한 코스를 삭제할까요?",
             isPresented: store.state.isPresented
         ) {
             store.dispatch(.alertCancel)


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 수집함 custom alert 오타 수정

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| 오타 수정 | <img src = "https://github.com/user-attachments/assets/049d196d-86ff-49dc-97eb-f3c613e72d5d" width ="250"> | <img src = "https://github.com/user-attachments/assets/8395da4e-728b-4c6a-b4aa-e2059830a2e5" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### custom alert title 분기처리
```Swift
title: archiveCategory == .place
    ? "선택한 장소를 삭제할까요?"
    : "선택한 코스를 삭제할까요?",
```
title에서 삼항연산자를 통해서 장소와 코스로 나눠서 alert이 뜨게 했습니다.

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #223 

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 추후에 분기 처리를 뷰를 아예 분리해서 구현하게 되면 이때 custom alert도 수정될 거 같아요!
