### PR TITLE
[refactor/#237] 장소 상세 페이지 UI 수정사항 반영

### DIFF
--- a/Solply/Solply/Global/Component/SolplySaveButton.swift
+++ b/Solply/Solply/Global/Component/SolplySaveButton.swift
@@ -36,26 +36,18 @@ struct SolplySaveButton: View {
         Button {
             action?()
         } label: {
-            HStack(alignment: .center, spacing: 4.adjustedWidth) {
-                Text(isSelected ? "저장된 \(contentType.title)" : "\(contentType.title) 저장")
-                    .applySolplyFont(.button_14_m)
-                    .foregroundStyle(isEnabled ? (isSelected ? .red500: .purple600) : .gray400)
+            ZStack(alignment: .center) {
+                Circle()
+                    .foregroundColor(isEnabled ? (isSelected ? .red100 : .coreWhite) : .coreWhite)
+                    .frame(width: 48.adjustedWidth, height: 48.adjustedHeight)
                 
-                Image(.logoVector)
+                Image(isSelected ? .bookmarkFilledIcon : .bookmarkIcon)
                     .resizable()
                     .renderingMode(.template)
-                    .frame(width: 36.adjustedWidth, height: 36.adjustedHeight)
+                    .frame(width: 28.adjustedWidth, height: 28.adjustedHeight)
                     .aspectRatio(contentMode: .fit)
                     .foregroundStyle(isEnabled ? (isSelected ? .red500 : .purple600) : .gray400)
             }
-            .frame(
-                height: 47.adjustedHeight,
-                alignment: .trailing
-            )
-            .padding(.trailing, 8.adjustedWidth)
-            .padding(.leading, 16.adjustedWidth)
-            .background(isEnabled ? (isSelected ? .red100 : .coreWhite) : .coreWhite)
-            .capsuleClipped()
             .animation(.easeInOut(duration: 0.2), value: isEnabled)
             .animation(.easeInOut(duration: 0.2), value: isSelected)
         }

--- a/Solply/Solply/Global/DesignSystem/Assets.xcassets/Image-icon/bookmark-filled-icon.imageset/Contents.json
+++ b/Solply/Solply/Global/DesignSystem/Assets.xcassets/Image-icon/bookmark-filled-icon.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "Saved=true.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Solply/Solply/Global/DesignSystem/Assets.xcassets/Image-icon/bookmark-filled-icon.imageset/Saved=true.svg
+++ b/Solply/Solply/Global/DesignSystem/Assets.xcassets/Image-icon/bookmark-filled-icon.imageset/Saved=true.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 4H18.9833L19 20L12.3095 15.8051L5 20V4Z" fill="#EA867B" stroke="#EA867B" stroke-width="1.5" stroke-linejoin="bevel"/>
+</svg>

--- a/Solply/Solply/Presentation/Place/Component/View/PlaceDetailMapView.swift
+++ b/Solply/Solply/Presentation/Place/Component/View/PlaceDetailMapView.swift
@@ -20,11 +20,11 @@ struct PlaceDetailMapView: UIViewRepresentable {
     var saveButtonEnabled: Bool
     var findDirectionEnabled: Bool
     
-    private let zoomLevel: Double = 16
+    private let zoomLevel: Double = 17
     private let contentInset: UIEdgeInsets = UIEdgeInsets(
         top: 0,
         left: 0,
-        bottom: 480.adjustedHeight,
+        bottom: 450.adjustedHeight,
         right: 0
     )
     
@@ -104,7 +104,7 @@ private extension PlaceDetailMapView {
         marker.position = NMGLatLng(lat: latitude, lng: longitude)
         marker.width = 36.adjustedWidth
         marker.height = 36.adjustedHeight
-        marker.anchor = CGPoint(x: 0.5, y: 0.5)
+        marker.anchor = CGPoint(x: 0.5, y: 1.0)
         marker.mapView = mapView
         context.coordinator.marker = marker
     }

--- a/Solply/Solply/Presentation/Place/Component/View/PlaceDetailMapView.swift
+++ b/Solply/Solply/Presentation/Place/Component/View/PlaceDetailMapView.swift
@@ -24,7 +24,7 @@ struct PlaceDetailMapView: UIViewRepresentable {
     private let contentInset: UIEdgeInsets = UIEdgeInsets(
         top: 0,
         left: 0,
-        bottom: 450.adjustedHeight,
+        bottom: 430.adjustedHeight,
         right: 0
     )
     

--- a/Solply/Solply/Presentation/Place/Component/View/PlaceInformationView.swift
+++ b/Solply/Solply/Presentation/Place/Component/View/PlaceInformationView.swift
@@ -66,7 +66,7 @@ struct PlaceInformationView: View {
 
 extension PlaceInformationView {
     private var title: some View {
-        VStack(alignment: .leading, spacing: 4.adjustedHeight) {
+        VStack(alignment: .leading, spacing: 8.adjustedHeight) {
             HStack(alignment: .center, spacing: 8.adjustedWidth) {
                 PlaceCategoryTag(placeCategory: primaryTag)
                 

--- a/Solply/Solply/Presentation/Place/Component/View/PlaceInformationView.swift
+++ b/Solply/Solply/Presentation/Place/Component/View/PlaceInformationView.swift
@@ -59,7 +59,10 @@ struct PlaceInformationView: View {
                 mainImage
                 
                 information
+                
+                reportButton
             }
+            .padding(.bottom, 300.adjustedHeight)
         }
     }
 }
@@ -134,7 +137,45 @@ extension PlaceInformationView {
             borderWidth: 1
         )
         .padding(.horizontal, 16.adjustedWidth)
-        .padding(.bottom, 40.adjustedHeight)
+    }
+    
+    private var reportButton: some View {
+        HStack(alignment: .center, spacing: 4.adjustedWidth) {
+            Image(.warningIcon)
+                .resizable()
+                .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+            
+            Text("잘못된 정보가 있어요.")
+                .applySolplyFont(.body_14_r)
+                .foregroundStyle(.gray800)
+            
+            Spacer()
+            
+            Button {
+                // TODO: - 제보하기 뷰 연결
+            } label: {
+                HStack(alignment: .center, spacing: 0) {
+                    Text("오류 제보하기")
+                        .applySolplyFont(.button_14_m)
+                        .foregroundStyle(.red600)
+                    
+                    Image(.arrowRightIcon)
+                        .resizable()
+                        .renderingMode(.template)
+                        .foregroundStyle(.red600)
+                        .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                }
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 20.adjustedWidth)
+        .padding(.vertical, 12.adjustedHeight)
+        .addBorder(
+            .roundedRectangle(cornerRadius: 20),
+            borderColor: .gray200,
+            borderWidth: 1
+        )
+        .padding(.horizontal, 16.adjustedWidth)
     }
 }
 


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 장소 상세 페이지에 UI 수정사항을 반영했어요
- 바텀시트 확장은 다음 이슈에서 진행하겠습니다

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| 수정사항 반영 | <img src = "https://github.com/user-attachments/assets/5cbb8e22-399f-4bdd-9809-0a7212a6799e" width ="250"> | <img src = "https://github.com/user-attachments/assets/24084e45-8838-465d-8b81-3743eeb4a3b4" width ="250"> |

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #237 

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 저장 버튼 눌렸을 때 asset이 없어서 추가했어요