### PR TITLE
[refactor/#251] 프로젝트 추가 세팅 & Alert 수정

### DIFF
--- a/Solply/Solply.xcodeproj/project.pbxproj
+++ b/Solply/Solply.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -352,6 +353,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Solply/Solply.xcodeproj/project.pbxproj
+++ b/Solply/Solply.xcodeproj/project.pbxproj
@@ -309,8 +309,8 @@
 				INFOPLIST_FILE = Solply/Global/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "솔플리";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "앱이 위치 정보를 사용하여 위경도를 표시합니다.";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "위치 정보를 기반으로 현재 위치, 주변 검색, 길찾기 정보를 제공합니다.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = test;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "앱이 위치 정보를 기반으로 현재 위치, 주변 검색, 길찾기 정보를 제공합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "앱에서 사진을 보려면 솔플리가 사진 라이브러리에 액세스 할 수 있어야 합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -345,8 +345,8 @@
 				INFOPLIST_FILE = Solply/Global/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "솔플리";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "앱이 위치 정보를 사용하여 위경도를 표시합니다.";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "위치 정보를 기반으로 현재 위치, 주변 검색, 길찾기 정보를 제공합니다.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = test;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "앱이 위치 정보를 기반으로 현재 위치, 주변 검색, 길찾기 정보를 제공합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "앱에서 사진을 보려면 솔플리가 사진 라이브러리에 액세스 할 수 있어야 합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Solply/Solply.xcodeproj/project.pbxproj
+++ b/Solply/Solply.xcodeproj/project.pbxproj
@@ -307,8 +307,10 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Solply/Global/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "솔플리";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "앱이 위치 정보를 사용하여 위경도를 표시합니다.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "위치 정보를 기반으로 현재 위치, 주변 검색, 길찾기 정보를 제공합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = test;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -341,8 +343,10 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Solply/Global/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "솔플리";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "앱이 위치 정보를 사용하여 위경도를 표시합니다.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "위치 정보를 기반으로 현재 위치, 주변 검색, 길찾기 정보를 제공합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = test;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Solply/Solply.xcodeproj/project.pbxproj
+++ b/Solply/Solply.xcodeproj/project.pbxproj
@@ -314,8 +314,8 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -351,8 +351,8 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Solply/Solply/Application/RootView.swift
+++ b/Solply/Solply/Application/RootView.swift
@@ -18,7 +18,7 @@ struct RootView: View {
                 .navigationDestination(for: AppDestination.self) { $0.build() }
         }
         .customAlert(alertManager: alertManager)
-        .toast(toastManager: toastManager)
+        .customToast(toastManager: toastManager)
         .environmentObject(alertManager)
         .environmentObject(toastManager)
         .environmentObject(appCoordinator)

--- a/Solply/Solply/Application/RootView.swift
+++ b/Solply/Solply/Application/RootView.swift
@@ -10,13 +10,16 @@ import SwiftUI
 struct RootView: View {
     @StateObject private var appCoordinator = AppCoordinator()
     @StateObject private var toastManager = ToastManager()
+    @StateObject private var alertManager = AlertManager()
     
     var body: some View {
         NavigationStack(path: $appCoordinator.path) {
             appCoordinator.root.build()
                 .navigationDestination(for: AppDestination.self) { $0.build() }
         }
+        .customAlert(alertManager: alertManager)
         .toast(toastManager: toastManager)
+        .environmentObject(alertManager)
         .environmentObject(toastManager)
         .environmentObject(appCoordinator)
         .animation(.easeInOut(duration: 0.2), value: appCoordinator.root)

--- a/Solply/Solply/Application/RootView.swift
+++ b/Solply/Solply/Application/RootView.swift
@@ -9,12 +9,15 @@ import SwiftUI
 
 struct RootView: View {
     @StateObject private var appCoordinator = AppCoordinator()
+    @StateObject private var toastManager = ToastManager()
     
     var body: some View {
         NavigationStack(path: $appCoordinator.path) {
             appCoordinator.root.build()
                 .navigationDestination(for: AppDestination.self) { $0.build() }
         }
+        .toast(toastManager: toastManager)
+        .environmentObject(toastManager)
         .environmentObject(appCoordinator)
         .animation(.easeInOut(duration: 0.2), value: appCoordinator.root)
     }

--- a/Solply/Solply/Global/Component/SolplyPhotosPicker.swift
+++ b/Solply/Solply/Global/Component/SolplyPhotosPicker.swift
@@ -13,6 +13,7 @@ struct SolplyPhotosPicker: View {
     // MARK: - Properties
     
     @State private var isPickerPresented: Bool = false
+    @State private var isAlertPresented: Bool = false
     @State private var selectedItems: [PhotosPickerItem] = []
     @State private var selectedImages: [UIImage] = []
     
@@ -38,6 +39,16 @@ struct SolplyPhotosPicker: View {
                     emptyPhotoCell
                 }
             }
+        }
+        .alert("사진 접근 제한 걸림 ㅋㅋㅠㅠ", isPresented: $isAlertPresented) {
+            Button("취소", role: .cancel) {
+                print("확인 눌림")
+            }
+            Button("설정", role: .destructive) {
+                print("설정 눌림")
+            }
+        } message: {
+            Text("접근 제한을 풀ㅇㅋㅋ")
         }
         .photosPicker(
             isPresented: $isPickerPresented,
@@ -84,7 +95,7 @@ extension SolplyPhotosPicker {
     
     private var addPhotoCell: some View {
         Button {
-            isPickerPresented = true
+            requestPhotoAuthorization()
         } label: {
             Rectangle()
                 .frame(width: 72.adjustedWidth, height: 72.adjustedHeight)
@@ -102,7 +113,7 @@ extension SolplyPhotosPicker {
     
     private func selectedPhotoCell(_ image: UIImage) -> some View {
         Button {
-            isPickerPresented = true
+            requestPhotoAuthorization()
         } label: {
             Image(uiImage: image)
                 .resizable()
@@ -111,6 +122,26 @@ extension SolplyPhotosPicker {
                 .cornerRadius(12, corners: .allCorners)
         }
         .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Functions
+
+extension SolplyPhotosPicker {
+    private func requestPhotoAuthorization() {
+        PHPhotoLibrary.requestAuthorization(for: .readWrite) { status in
+            switch status {
+            case .authorized, .limited:
+                isPickerPresented = true
+                
+            case .notDetermined, .restricted, .denied:
+                isPickerPresented = false
+                isAlertPresented = true
+                
+            @unknown default:
+                isPickerPresented = false
+            }
+        }
     }
 }
 

--- a/Solply/Solply/Global/Component/SolplyPhotosPicker.swift
+++ b/Solply/Solply/Global/Component/SolplyPhotosPicker.swift
@@ -12,6 +12,7 @@ struct SolplyPhotosPicker: View {
     
     // MARK: - Properties
     
+    @EnvironmentObject private var alertManager: AlertManager
     @State private var isPickerPresented: Bool = false
     @State private var isAlertPresented: Bool = false
     @State private var selectedItems: [PhotosPickerItem] = []
@@ -39,16 +40,6 @@ struct SolplyPhotosPicker: View {
                     emptyPhotoCell
                 }
             }
-        }
-        .alert("사진 접근 제한 걸림 ㅋㅋㅠㅠ", isPresented: $isAlertPresented) {
-            Button("취소", role: .cancel) {
-                print("확인 눌림")
-            }
-            Button("설정", role: .destructive) {
-                print("설정 눌림")
-            }
-        } message: {
-            Text("접근 제한을 풀ㅇㅋㅋ")
         }
         .photosPicker(
             isPresented: $isPickerPresented,
@@ -130,17 +121,30 @@ extension SolplyPhotosPicker {
 extension SolplyPhotosPicker {
     private func requestPhotoAuthorization() {
         PHPhotoLibrary.requestAuthorization(for: .readWrite) { status in
-            switch status {
-            case .authorized, .limited:
-                isPickerPresented = true
-                
-            case .notDetermined, .restricted, .denied:
-                isPickerPresented = false
-                isAlertPresented = true
-                
-            @unknown default:
-                isPickerPresented = false
+            DispatchQueue.main.async {
+                switch status {
+                case .authorized, .limited:
+                    isPickerPresented = true
+                    
+                case .notDetermined, .restricted, .denied:
+                    isPickerPresented = false
+                    showAlert()
+                    
+                @unknown default:
+                    isPickerPresented = false
+                    showAlert()
+                }
             }
+        }
+    }
+    
+    private func showAlert() {
+        alertManager.showAlert(alertType: .photoPermissionDenied, onCancel: nil) {
+            guard let url = URL(string: UIApplication.openSettingsURLString),
+                  UIApplication.shared.canOpenURL(url) else { return }
+            
+            
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }
     }
 }

--- a/Solply/Solply/Global/Enum/AlertType.swift
+++ b/Solply/Solply/Global/Enum/AlertType.swift
@@ -8,13 +8,35 @@
 import Foundation
 
 enum AlertType {
-    case delete
-    case leave
-
-    var mainText: String {
+    case deletePlace
+    case deleteCourse
+    case leaveCourseDetail
+    case photoPermissionDenied
+    
+    var title: String {
         switch self {
-        case .delete: return "삭제"
-        case .leave: return "나가기"
+        case .deletePlace: return "선택한 장소를 삭제할까요?"
+        case .deleteCourse: return "선택한 코스를 삭제할까요?"
+        case .leaveCourseDetail: return "변경 사항을 저장하지 않고\n나가시겠어요?"
+        case .photoPermissionDenied: return "앱에서 사진을 사용하려면 권한을 허용해주세요"
+        }
+    }
+    
+    var cancelText: String {
+        switch self {
+        case .deletePlace, .deleteCourse, .leaveCourseDetail, .photoPermissionDenied:
+            return "취소"
+        }
+    }
+    
+    var confirmText: String {
+        switch self {
+        case .deletePlace, .deleteCourse:
+            return "삭제"
+        case .leaveCourseDetail:
+            return "나가기"
+        case .photoPermissionDenied:
+            return "설정으로 이동"
         }
     }
 }

--- a/Solply/Solply/Global/Info.plist
+++ b/Solply/Solply/Global/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
-	<key>CFBundleDisplayName</key>
-	<string>솔플리</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -17,6 +15,8 @@
 			</array>
 		</dict>
 	</array>
+	<key>KAKAO_NATIVE_APP_KEY</key>
+	<string>$(KAKAO_NATIVE_APP_KEY)</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>kakaokompassauth</string>
@@ -24,8 +24,6 @@
 		<string>kakaotalk</string>
 		<string>nmap</string>
 	</array>
-	<key>KAKAO_NATIVE_APP_KEY</key>
-	<string>$(KAKAO_NATIVE_APP_KEY)</string>
 	<key>NMFClientId</key>
 	<string>$(NMFNcpKeyId)</string>
 	<key>NSAppTransportSecurity</key>
@@ -39,5 +37,7 @@
 		<string>Pretendard-Regular.otf</string>
 		<string>Pretendard-Medium.otf</string>
 	</array>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>사진점 보여줘잉~</string>
 </dict>
 </plist>

--- a/Solply/Solply/Global/Info.plist
+++ b/Solply/Solply/Global/Info.plist
@@ -37,7 +37,5 @@
 		<string>Pretendard-Regular.otf</string>
 		<string>Pretendard-Medium.otf</string>
 	</array>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>사진점 보여줘잉~</string>
 </dict>
 </plist>

--- a/Solply/Solply/Global/Modifier/CustomAlertModifier.swift
+++ b/Solply/Solply/Global/Modifier/CustomAlertModifier.swift
@@ -11,27 +11,7 @@ struct CustomAlertModifier: ViewModifier {
     
     // MARK: - Properties
     
-    private let alertType: AlertType
-    private let title: String
-    private let isPresented: Bool
-    private let onCancel: (() -> Void)?
-    private let onConfirm: (() -> Void)?
-    
-    // MARK: - Initializers
-    
-    init(
-        alertType: AlertType,
-        title: String,
-        isPresented: Bool,
-        onCancel: (() -> Void)?,
-        onConfirm: (() -> Void)?
-    ) {
-        self.alertType = alertType
-        self.title = title
-        self.isPresented = isPresented
-        self.onCancel = onCancel
-        self.onConfirm = onConfirm
-    }
+    @ObservedObject var alertManager: AlertManager
     
     // MARK: - Body
     
@@ -39,22 +19,22 @@ struct CustomAlertModifier: ViewModifier {
         content
             .overlay(
                 Group {
-                    if isPresented {
+                    if alertManager.isPresented {
                         ZStack(alignment: .center) {
                             Color.coreBlackO40
                                 .ignoresSafeArea()
                             
                             VStack(spacing: 8.adjustedHeight) {
-                                Text(title)
+                                Text(alertManager.alertType.title)
                                     .applySolplyFont(.body_14_r)
                                     .frame(width: 236.adjustedWidth, height: 65.adjustedHeight)
                                     .multilineTextAlignment(.center)
                                 
                                 HStack(alignment: .center, spacing: 0.adjustedWidth) {
                                     Button {
-                                        onCancel?()
+                                        alertManager.onCancel?()
                                     } label: {
-                                        Text("취소")
+                                        Text(alertManager.alertType.cancelText)
                                             .applySolplyFont(.button_14_r)
                                             .frame(width: 114.adjustedWidth, height: 48.adjustedHeight)
                                             .foregroundStyle(.gray900)
@@ -62,9 +42,9 @@ struct CustomAlertModifier: ViewModifier {
                                     .buttonStyle(.plain)
                                     
                                     Button {
-                                        onConfirm?()
+                                        alertManager.onConfirm?()
                                     } label: {
-                                        Text(alertType.mainText)
+                                        Text(alertManager.alertType.confirmText)
                                             .applySolplyFont(.button_14_r)
                                             .frame(width: 122.adjustedWidth, height: 48.adjustedHeight)
                                             .foregroundStyle(.coreWhite)
@@ -81,27 +61,13 @@ struct CustomAlertModifier: ViewModifier {
                         .transition(.opacity)
                     }
                 }
-                .animation(.easeInOut(duration: 0.2), value: isPresented)
+                    .animation(.easeInOut(duration: 0.2), value: alertManager.isPresented)
             )
     }
 }
 
 extension View {
-    func customAlert(
-        alertType: AlertType,
-        title: String,
-        isPresented: Bool,
-        onCancel: (() -> Void)?,
-        onConfirm: (() -> Void)?
-    ) -> some View {
-        self.modifier(
-            CustomAlertModifier(
-                alertType: alertType,
-                title: title,
-                isPresented: isPresented,
-                onCancel: onCancel,
-                onConfirm: onConfirm
-            )
-        )
+    func customAlert(alertManager: AlertManager) -> some View {
+        self.modifier(CustomAlertModifier(alertManager: alertManager))
     }
 }

--- a/Solply/Solply/Global/Modifier/CustomAlertModifier.swift
+++ b/Solply/Solply/Global/Modifier/CustomAlertModifier.swift
@@ -59,6 +59,7 @@ struct CustomAlertModifier: ViewModifier {
                                             .frame(width: 114.adjustedWidth, height: 48.adjustedHeight)
                                             .foregroundStyle(.gray900)
                                     }
+                                    .buttonStyle(.plain)
                                     
                                     Button {
                                         onConfirm?()
@@ -70,6 +71,7 @@ struct CustomAlertModifier: ViewModifier {
                                             .background(.gray900)
                                             .capsuleClipped()
                                     }
+                                    .buttonStyle(.plain)
                                 }
                             }
                             .frame(width: 260.adjustedWidth, height: 145.adjustedHeight)

--- a/Solply/Solply/Global/Modifier/CustomToastModifier.swift
+++ b/Solply/Solply/Global/Modifier/CustomToastModifier.swift
@@ -1,5 +1,5 @@
 //
-//  ToastModifier.swift
+//  CustomToastModifier.swift
 //  Solply
 //
 //  Created by 김승원 on 7/12/25.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct ToastModifier: ViewModifier {
+struct CustomToastModifier: ViewModifier {
     
     // MARK: - Properties
     
@@ -38,7 +38,7 @@ struct ToastModifier: ViewModifier {
 }
 
 extension View {
-    func toast(toastManager: ToastManager) -> some View {
-        self.modifier(ToastModifier(toastManager: toastManager))
+    func customToast(toastManager: ToastManager) -> some View {
+        self.modifier(CustomToastModifier(toastManager: toastManager))
     }
 }

--- a/Solply/Solply/Global/Util/AlertManager.swift
+++ b/Solply/Solply/Global/Util/AlertManager.swift
@@ -37,7 +37,7 @@ class AlertManager: ObservableObject {
         self.isPresented = true
     }
     
-    func dismiss() {
+    private func dismiss() {
         self.isPresented = false
         self.onCancel = nil
         self.onConfirm = nil

--- a/Solply/Solply/Global/Util/AlertManager.swift
+++ b/Solply/Solply/Global/Util/AlertManager.swift
@@ -1,0 +1,45 @@
+//
+//  AlertManager.swift
+//  Solply
+//
+//  Created by 김승원 on 9/24/25.
+//
+
+import SwiftUI
+
+class AlertManager: ObservableObject {
+    
+    // MARK: - Properties
+    
+    @Published var isPresented: Bool = false
+    @Published var alertType: AlertType = .deleteCourse
+    @Published var onCancel: (() -> Void)? = nil
+    @Published var onConfirm: (() -> Void)? = nil
+    
+    // MARK: - Functions
+    
+    func showAlert(
+        alertType: AlertType,
+        onCancel: (() -> Void)? = nil,
+        onConfirm: (() -> Void)? = nil
+    ) {
+        self.alertType = alertType
+        self.onCancel = {
+            onCancel?()
+            self.dismiss()
+        }
+        
+        self.onConfirm = {
+            onConfirm?()
+            self.dismiss()
+        }
+        
+        self.isPresented = true
+    }
+    
+    func dismiss() {
+        self.isPresented = false
+        self.onCancel = nil
+        self.onConfirm = nil
+    }
+}

--- a/Solply/Solply/Global/Util/LocationManager.swift
+++ b/Solply/Solply/Global/Util/LocationManager.swift
@@ -5,8 +5,8 @@
 //  Created by 김승원 on 7/17/25.
 //
 
-import Foundation
 import CoreLocation
+import Foundation
 
 final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     
@@ -31,7 +31,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         case .authorizedWhenInUse, .authorizedAlways:
             locationManager.startUpdatingLocation()
         default:
-            break // 권한 거부 등
+            break
         }
     }
 

--- a/Solply/Solply/Global/Util/ToastManager.swift
+++ b/Solply/Solply/Global/Util/ToastManager.swift
@@ -60,7 +60,7 @@ class ToastManager: ObservableObject {
         DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: workItem!)
     }
     
-    func hideToast() {
+    private func hideToast() {
         workItem?.cancel()
         
         withAnimation(.easeInOut(duration: 0.3)) {

--- a/Solply/Solply/Presentation/Archive/ArchiveList/Intent/ArchiveListAction.swift
+++ b/Solply/Solply/Presentation/Archive/ArchiveList/Intent/ArchiveListAction.swift
@@ -13,10 +13,6 @@ enum ArchiveListAction {
     case toggleSelect
     case toggleCancel
     
-    case showAlert
-    case alertCancel
-    case alertDelete
-    
     // api
     case fetchCourseList(townId: Int, placeId: Int?)
     case courseListFetched(courseLists: [CourseArchiveDTO])

--- a/Solply/Solply/Presentation/Archive/ArchiveList/State/ArchiveListReducer.swift
+++ b/Solply/Solply/Presentation/Archive/ArchiveList/State/ArchiveListReducer.swift
@@ -32,18 +32,6 @@ enum ArchiveListReducer {
             state.selectedCourseIds.removeAll()
             state.activeDelete = false
             
-        case .showAlert:
-            state.isPresented = true
-            
-        case .alertCancel:
-            state.isPresented = false
-            
-        case .alertDelete:
-            state.isPresented = false
-            state.activeDelete = false
-            
-        
-            
         case .fetchCourseList:
             break
             

--- a/Solply/Solply/Presentation/Archive/ArchiveList/State/ArchiveListState.swift
+++ b/Solply/Solply/Presentation/Archive/ArchiveList/State/ArchiveListState.swift
@@ -13,7 +13,6 @@ struct ArchiveListState {
     var activeDelete: Bool = false
     var activeCancel: Bool = false
     
-    var isPresented: Bool = false
     var courses: [CourseArchiveDTO] = []
     var places: [PlaceDTO] = []
 }

--- a/Solply/Solply/Presentation/Archive/ArchiveList/View/ArchiveListView.swift
+++ b/Solply/Solply/Presentation/Archive/ArchiveList/View/ArchiveListView.swift
@@ -12,6 +12,7 @@ struct ArchiveListView: View {
     // MARK: - Properties
     
     @EnvironmentObject var appCoordinator: AppCoordinator
+    @EnvironmentObject var alertManager: AlertManager
     @StateObject var store = ArchiveListStore()
     
     private let archiveCategory: SolplyContentType
@@ -46,7 +47,7 @@ struct ArchiveListView: View {
                         Spacer()
                         
                         Button {
-                            store.dispatch(.showAlert)
+                            showAlert()
                         } label: {
                             Text("삭제")
                                 .applySolplyFont(.button_14_r)
@@ -80,17 +81,17 @@ struct ArchiveListView: View {
             store.dispatch(.fetchPlaceList(townId: townId, isBookmarkSearch: true, mainTagId: nil, subTagAIdList: nil, subTagBIdList: nil))
             store.dispatch(.fetchCourseList(townId: townId, placeId: nil))
         }
-        .customAlert(
-            alertType: .delete,
-            title: archiveCategory == .place
-                    ? "선택한 장소를 삭제할까요?"
-                    : "선택한 코스를 삭제할까요?",
-            isPresented: store.state.isPresented
+    }
+}
+
+// MARK: - Functions
+
+extension ArchiveListView {
+    private func showAlert() {
+        alertManager.showAlert(
+            alertType: archiveCategory == .place ? .deletePlace : .deleteCourse,
+            onCancel: nil
         ) {
-            store.dispatch(.alertCancel)
-        } onConfirm: {
-            store.dispatch(.alertDelete)
-            
             if archiveCategory == .place {
                 store.dispatch(.removePlaceList(PlaceIds: Array(store.state.selectedPlaceIds)))
             } else {

--- a/Solply/Solply/Presentation/Course/CourseDetail/Intent/CourseDetailAction.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/Intent/CourseDetailAction.swift
@@ -24,10 +24,6 @@ enum CourseDetailAction {
     
     case showToastView(ToastContent)
     
-    case showAlert
-    case cancelAlert
-    case confirmAlert
-    
     case saveCourseToCurrent
     case saveCourseAsNew
     case saveCourseCancel

--- a/Solply/Solply/Presentation/Course/CourseDetail/State/CourseDetailReducer.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/State/CourseDetailReducer.swift
@@ -87,16 +87,7 @@ enum CourseDetailReducer {
             state.toastContent = toastContent
             state.draggedPlace = nil
             state.canDelete = .dismissed
-            state.isInDeleteZone = false
-            
-        case .showAlert:
-            state.isAlertPresented = true
-            
-        case .cancelAlert:
-            state.isAlertPresented = false
-            
-        case .confirmAlert:
-            state.isAlertPresented = false
+            state.isInDeleteZone = false        
             
         case .saveCourseToCurrent:
             state.isSaveOptionPresented = false

--- a/Solply/Solply/Presentation/Course/CourseDetail/State/CourseDetailState.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/State/CourseDetailState.swift
@@ -33,7 +33,6 @@ struct CourseDetailState {
     
     var toastContent: ToastContent?
     
-    var isAlertPresented: Bool = false
     var isSaveOptionPresented: Bool = false
     
     var draggedPlace: PlaceDetailInCourse?

--- a/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
@@ -13,6 +13,7 @@ struct CourseDetailView: View {
     
     @EnvironmentObject private var appCoordinator: AppCoordinator
     @EnvironmentObject private var toastManager: ToastManager
+    @EnvironmentObject private var alertManager: AlertManager
     @StateObject private var store = CourseDetailStore()
     @StateObject private var locationManager = LocationManager()
     
@@ -57,16 +58,6 @@ struct CourseDetailView: View {
                         )
                     }
                 }
-                .customAlert(
-                    alertType: .leave,
-                    title: "변경 사항을 저장하지 않고\n나가시겠어요?",
-                    isPresented: store.state.isAlertPresented) {
-                        store.dispatch(.cancelAlert)
-                    } onConfirm: {
-                        store.dispatch(.confirmAlert)
-                        appCoordinator.goBack()
-                    }
-            
             if fromArchive && !store.state.isEditing {
                 editButton
             }
@@ -132,7 +123,7 @@ extension CourseDetailView {
             .customNavigationBar(
                 .courseDetail(backAction: {
                     if store.state.isEditing {
-                        store.dispatch(.showAlert)
+                        showAlert()
                     } else {
                         appCoordinator.goBack()
                     }
@@ -465,6 +456,12 @@ extension CourseDetailView {
                     )
                 )
             )
+        }
+    }
+    
+    private func showAlert() {
+        alertManager.showAlert(alertType: .leaveCourseDetail, onCancel: nil) {
+            appCoordinator.goBack()
         }
     }
 }

--- a/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
@@ -11,9 +11,9 @@ struct CourseDetailView: View {
     
     // MARK: - Properties
     
-    @EnvironmentObject var appCoordinator: AppCoordinator
+    @EnvironmentObject private var appCoordinator: AppCoordinator
+    @EnvironmentObject private var toastManager: ToastManager
     @StateObject private var store = CourseDetailStore()
-    @StateObject private var toastManager = ToastManager()
     @StateObject private var locationManager = LocationManager()
     
     private var townId: Int
@@ -47,6 +47,7 @@ struct CourseDetailView: View {
                     guard let toastContent else { return }
                     
                     toastManager.showToast(content: toastContent) {
+                        print("Toast")
                         appCoordinator.navigate(
                             to: .courseDetail(
                                 townId: townId,
@@ -56,7 +57,6 @@ struct CourseDetailView: View {
                         )
                     }
                 }
-                .toast(toastManager: toastManager)
                 .customAlert(
                     alertType: .leave,
                     title: "변경 사항을 저장하지 않고\n나가시겠어요?",

--- a/Solply/Solply/Presentation/Place/PlaceDetail/View/PlaceDetailView.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/View/PlaceDetailView.swift
@@ -11,9 +11,9 @@ struct PlaceDetailView: View {
     
     // MARK: - Properties
     
-    @EnvironmentObject var appCoordinator: AppCoordinator
+    @EnvironmentObject private var appCoordinator: AppCoordinator
+    @EnvironmentObject private var toastManager: ToastManager
     @StateObject private var store = PlaceDetailStore()
-    @StateObject private var toastManager = ToastManager()
     @StateObject private var locationManager = LocationManager()
     
     private let townId: Int
@@ -71,7 +71,6 @@ struct PlaceDetailView: View {
                 }
             }
         }
-        .toast(toastManager: toastManager)
     }
 }
 

--- a/Solply/Solply/Presentation/TabBar/TabBarView.swift
+++ b/Solply/Solply/Presentation/TabBar/TabBarView.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 
-import CoreLocation
-
 struct TabBarView: View {
     
     // MARK: - Properties

--- a/Solply/Solply/Presentation/TabBar/TabBarView.swift
+++ b/Solply/Solply/Presentation/TabBar/TabBarView.swift
@@ -120,4 +120,5 @@ extension TabBarView {
 #Preview {
     TabBarView()
         .environmentObject(AppCoordinator())
+        .environmentObject(ToastManager())
 }


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 프로젝트 추가 세팅을 했습니다. (위치 권한, 사진 권한, 다크모드 막음, 가로모드 막음)
- `CustomAlert`에 대한 이슈가 있어서 살짝 손봤어요 (수용이형 자세히 보고 리뷰 달아주세요~)

|    구현 내용    |   사용자 위치 권한   |  사진 접근 권한   |   사진 권한 거부했을 때   |
| :-------------: | :----------: | :----------: | :----------: |
| iPhone 13 mini | <img src = "https://github.com/user-attachments/assets/371e3db5-a4b9-409b-ad3b-13bf79e0079d" width ="250"> | <img src = "https://github.com/user-attachments/assets/22b13ce6-f242-4874-bebc-45fdaf86a777" width ="250"> | <img src = "https://github.com/user-attachments/assets/aa3b82c9-8f0b-4ce0-a3f6-e5032bd31455" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
## 사진 권한 묻기
```Swift
// SolplyPhotosPicker.swift

extension SolplyPhotosPicker {
    private func requestPhotoAuthorization() {
        PHPhotoLibrary.requestAuthorization(for: .readWrite) { status in
            switch status {
            case .authorized, .limited:
                isPickerPresented = true
                
            case .notDetermined, .restricted, .denied:
                isPickerPresented = false
                isAlertPresented = true
                
            @unknown default:
                isPickerPresented = false
            }
        }
    }
}
```
`SolplyPhotosPicker` 컴포넌트에서 사용하는 코드입니다.
일단 이 피커컴포넌트에서 사진에 관련된 모든 로직을 처리하게 하고 싶어서 컴포넌트 내부에 작성했어요 (객체지향 어쩌구)

사진 권한 여부를 묻지 않아도 사진첩에 접근이 가능하긴 하지만,
나중에 이것 떄문에 리젝 많이 당한다고 해서 구현했습니다.
`PhotosUI`에 있는 `PHPhotoLibrary.requestAuthorization()` 를 사용하면 쉽게 가능하더라고요

사진 권한은 앱을 깔고 처음 권한 질문을 한 뒤로는 다시 실행되지는 않습니다.
따라서 권한을 거부했다가 다시 권한 승인을 하고 싶으면 사용자가 직접 설정에 들어가서 바꿔야 합니다.
따라서 더 나은 UX를 위해 사진 권한이 거부된 상태에서 사진 추가 버튼을 누르면 설정앱으로 유도하는 `alert창`을 추가했어요
### 근데 여기서 예상치 못한 문제가 발생!!
기존에 사용하던 `CustomAlert`를 사용하려고 했는데, 이 alert는 사용하는 뷰를 기준으로 **dimmedView**와 함께 **alert창**을 띄우기 때문에
해당 컴포넌트에서 사용하면 UI가 제대로 표시되지 않는 문제가 있었습니다.
(그래서 **iOS 기본 alert**를 사용하려 했지만, 서x영씨의 구리다는 피드백을 받고 이 `CustomAlert`를 컴포넌트 내부에서 사용할 방법을 열심히 모색해 보았습니다.)
<br>

## CustomAlert 전역으로 사용하기
### 기존 방식
```Swift
CourseDetailView
    .customAlert(...)

PlaceDetailView
    .customAlert(...)
```
원래의 방식은 alert을 사용하고자 하는 뷰에 `.customAlert` modifer를 붙여 사용하는 방식이었습니다.
=> 사용하는 뷰의 크기에 따라 UI가 다르게 배치 됨 (그래서 화면 전체를 사용하는 뷰에서만 사용해야 원하는 모습대로 나옴)
=> 사진 선택 컴포넌트에서 사용하면 Alert창이 잘려서 나옴!
<br>

### 수정된 방식
```Swift
// RootView

var body: some View {
    대충 내부 뷰들
        .customAlert(...) // 하나로 해결!
}
```
이렇게 `RootView` 즉, 최상위 뷰에 붙이고 AlertManager를 구현하여 하위 뷰에서 alert창 띄워줘~ 하면 상위뷰에서 alert이 띄워지기 때문에
원하는대로 컴포넌트 내부에서도 자유롭게 사용이 가능하겠죠! (하는 김에 Toast도 같은 방식으로 수정했어요)
<br>

### RootView에서 (최상위 뷰)
```Swift
// RootView.swift

struct RootView: View {
    @StateObject private var appCoordinator = AppCoordinator()
    @StateObject private var toastManager = ToastManager() // Toast의 상태를 전역으로 관리
    @StateObject private var alertManager = AlertManager() // Alert의 상태를 전역으로 관리
    
    var body: some View {
        NavigationStack(path: $appCoordinator.path) {
            appCoordinator.root.build()
                .navigationDestination(for: AppDestination.self) { $0.build() }
        }
        .customAlert(alertManager: alertManager) // alertManager 상태를 관찰하고, 상태에 따라 커스텀 Alert 표시
        .customToast(toastManager: toastManager) // toastManager 상태를 관찰하고, 상태에 따라 커스텀 Toast 표시
        .environmentObject(alertManager)
        .environmentObject(toastManager)
        .environmentObject(appCoordinator)
        .animation(.easeInOut(duration: 0.2), value: appCoordinator.root)
    }
}
```
**Alert**의 상태를 전역으로 관리하는 **Manager**객체를 `@StateObject`로 선언한 뒤 `.environmentObject` **modifer**로 주입시켜줍니다.
그리고 `.customAlert` **modifer**가 `alertManager`의 상태를 관찰하게 되고, 상태에 따라 alert창을 **최상단 뷰** `RootView`에 띄우는 방식입니다.
<br>

### AlertManager
```Swift
// AlertManager.swift

class AlertManager: ObservableObject {
    
    // MARK: - Properties
    
    @Published var isPresented: Bool = false
    @Published var alertType: AlertType = .deleteCourse
    @Published var onCancel: (() -> Void)? = nil
    @Published var onConfirm: (() -> Void)? = nil
    
    // MARK: - Functions
    
    func showAlert(
        alertType: AlertType,
        onCancel: (() -> Void)? = nil,
        onConfirm: (() -> Void)? = nil
    ) {
        self.alertType = alertType
        self.onCancel = {
            onCancel?()
            self.dismiss()
        }
        
        self.onConfirm = {
            onConfirm?()
            self.dismiss()
        }
        
        self.isPresented = true
    }
    
    private func dismiss() {
        self.isPresented = false
        self.onCancel = nil
        self.onConfirm = nil
    }
}
```
`AlertManager`입니다. 사용하는 뷰에서 이 객체를 `@EnvironmentObject`로 들고 있고(관찰하고) **alert**가 필요한 순간에 `alertManager.showAlert()`를 호출하여 내부적으로 상태를 변경합니다.
변경된 상태에 따라 이 객체를 `@ObservedObject`로 관찰하는 객체 (`CustomAlertModifier`)가 alert창을 띄워줍니다
<br>

### CustomAlertModifier
```Swift
// CustomAlertModifier.swift

struct CustomAlertModifier: ViewModifier {
    
    // MARK: - Properties
    
    @ObservedObject var alertManager: AlertManager
    
    // MARK: - Body
    
    func body(content: Content) -> some View {
        content
            .overlay(
               // 기존 Alert UI
            )
    }
}

extension View {
    func customAlert(alertManager: AlertManager) -> some View {
        self.modifier(CustomAlertModifier(alertManager: alertManager))
    }
}
```
`CustomAlertModifier` 코드는 기존 코드랑 비슷하지만,
기존에 `isPresented`와 같이 상태를 직접 갖고 관리했다면,
지금 구조에서는 `AlertManager`를 `@ObservedObject`로 관찰! (들고 있는 것이 아님),
`AlertManager`의 `@Published`로 선언된 프로퍼티를 기준으로 상태를 변경하고 UI를 그립니다.
<br>

### 사용하는 뷰에서
```Swift
struct CourseDetailView: View {
    
    // MARK: - Properties
    
    @EnvironmentObject private var appCoordinator: AppCoordinator
    @EnvironmentObject private var alertManager: AlertManager
    // ...
```
이렇게 AppCoordinator처럼 `@EnvironmentObject`로 관찰하고,
```Swift
Button {
    alertManager.showAlert(alertType: .leaveCourseDetail) {
        // 취소 버튼 눌렀을 때 (Optional)
    } onConfirm: {
        // 확인 버튼 눌렀을 때 (Optional)
    }
} label: {
    // 버튼 UI
}
```
**alert**창이 필요할 때 아까 `showAlert()`함수를 호출하기만 하면 됩니다.
<br>

### Alert 수정에 따른 state변경
기존에 **Alert**를 띄울지 말지에 대한 상태를 각각의 뷰에서 `State`로 보관하고 있었습니다.
따라서 `Reducer`에서 직접 `State`의 **alert표시여부 상태**를 갈아 끼워줬어요 (불편해!)
이제 **Alert**를 전역으로 관리하기 때문에 **Alert**를 관리하는 `state`와 `action`을 따로 두지 않아도 됩니다. (`appCoordinator`처럼)

```Swift
// 기존 코드
Button {
    store.dispatch.showAlert(...) // Reducer 내부적으로 Alert를 관리...
} label {
    // 버튼 UI
}

// 수정된 코드
Button {
    alertManager.showAlert(...) // 간편!
} label {
    // 버튼 UI
}
```
ps. `Toast`도 위처럼 바꿀 수 있는데, `Toast`는 직접 버튼을 누를 때 보다
특정 상황에 상태가 변경되었을 때 자동적으로 띄워지는 로직이 많기 때문에 수정하지 않았습니다.

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #251 

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 프로젝트 설정만 만지려고 했는데,, 피커 수정하다 이렇게 뚱pr이 되어버렸네요.. 미안함니다
- 자세히 보시고 모르겠는 거, 이상한 거 있으면 맘껏 물어봐 주세요
