### PR TITLE
[feat/#256] 제보하기 뷰 UI, 화면전환 구현, safeArea 문제 수정

### DIFF
--- a/Solply/Solply/Global/Component/SolplyTextEditor.swift
+++ b/Solply/Solply/Global/Component/SolplyTextEditor.swift
@@ -12,6 +12,7 @@ struct SolplyTextEditor: View {
     // MARK: - Properties
     
     @State private var text: String = ""
+    
     private let placeholder: String
     private let onTextChanged: ((String) -> Void)?
     

--- a/Solply/Solply/Global/Enum/NavigationBarType.swift
+++ b/Solply/Solply/Global/Enum/NavigationBarType.swift
@@ -17,7 +17,7 @@ enum NavigationBarType {
     case archiveList(title: String, backAction: () -> Void)
     case frequentTown(backAction: () -> Void)
     case placeSearch(backAction: () -> Void)
-    case reports(backAction: () -> Void)
+    case reports(reportStep: ReportsStep, backAction: () -> Void)
     case myPage(backAction: () -> Void)
     case myPageEdit(title: String, backAction: () -> Void)
 }

--- a/Solply/Solply/Global/Enum/ReportsStep.swift
+++ b/Solply/Solply/Global/Enum/ReportsStep.swift
@@ -10,4 +10,5 @@ import Foundation
 enum ReportsStep {
     case reportsSelect
     case reportsDetail
+    case reportsComplete
 }

--- a/Solply/Solply/Global/Enum/ReportsStep.swift
+++ b/Solply/Solply/Global/Enum/ReportsStep.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 enum ReportsStep {
-    case ReportsSelect
-    case ReportsDetail
-    case ReportsComplete
+    case reportsSelect
+    case reportsDetail
 }

--- a/Solply/Solply/Global/Modifier/CustomAlertModifier.swift
+++ b/Solply/Solply/Global/Modifier/CustomAlertModifier.swift
@@ -19,7 +19,7 @@ struct CustomAlertModifier: ViewModifier {
         content
             .overlay(
                 Group {
-                    if alertManager.isPresented,let alertType = alertManager.alertType {
+                    if alertManager.isPresented, let alertType = alertManager.alertType {
                         ZStack(alignment: .center) {
                             Color.coreBlackO40
                                 .ignoresSafeArea()

--- a/Solply/Solply/Global/Modifier/CustomNavigationBarModifier.swift
+++ b/Solply/Solply/Global/Modifier/CustomNavigationBarModifier.swift
@@ -83,6 +83,9 @@ extension View {
     @ViewBuilder
     func customNavigationBar(_ navigationBarType: NavigationBarType) -> some View {
         switch navigationBarType {
+            
+        // MARK: - Onboarding
+            
         case .onboarding(let backAction):
             self.modifier(
                 CustomNavigationBarModifier(
@@ -106,6 +109,8 @@ extension View {
                     backgroundColor: .gray100
                 )
             )
+            
+        // MARK: - Recommend
             
         case .recommend(let filterTitle, let filterAction, let settingAction):
             self.modifier(
@@ -150,6 +155,8 @@ extension View {
                     backgroundColor: .gray100
                 )
             )
+            
+        // MARK: - PlaceDetail
             
         case .placeDetail(let backAction, let homeAction):
             self.modifier(
@@ -197,6 +204,8 @@ extension View {
                 )
             )
             
+        // MARK: - CourseDetail
+            
         case .courseDetail(let backAction, let homeAction):
             self.modifier(
                 CustomNavigationBarModifier(
@@ -243,6 +252,8 @@ extension View {
                 )
             )
             
+        // MARK: - Archive
+            
         case .archive(let backAction):
             self.modifier(
                 CustomNavigationBarModifier(
@@ -267,6 +278,8 @@ extension View {
                     backgroundColor: .coreWhite
                 )
             )
+            
+        // MARK: - ArchiveList
             
         case .archiveList(let title, let backAction):
             self.modifier(
@@ -293,6 +306,8 @@ extension View {
                 )
             )
             
+        // MARK: - FrequentTown
+            
         case .frequentTown(let backAction):
             self.modifier(
                 CustomNavigationBarModifier(
@@ -318,23 +333,38 @@ extension View {
                 )
             )
             
-        case .reports(let backAction):
+        // MARK: - Reports
+            
+        case .reports(let reportsStep, let backAction):
             self.modifier(
                 CustomNavigationBarModifier(
                     centerView: {
-                        Text("제보하기")
-                            .applySolplyFont(.head_16_m)
+                        Group {
+                            if reportsStep == .reportsComplete {
+                                Text(" ")
+                            } else {
+                                Text("제보하기")
+                            }
+                        }
+                        .applySolplyFont(.head_16_m)
                     },
                     leftView: {
-                        Button {
-                            backAction()
-                        } label: {
-                            Image(.backIconIos)
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                        Group {
+                            if reportsStep == .reportsComplete {
+                                EmptyView()
+                                    .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                            } else {
+                                Button {
+                                    backAction()
+                                } label: {
+                                    Image(.backIconIos)
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(width: 24.adjustedWidth, height: 24.adjustedHeight)
+                                }
+                                .buttonStyle(.plain)
+                            }
                         }
-                        .buttonStyle(.plain)
                     },
                     rightView: {
                         EmptyView()
@@ -342,6 +372,8 @@ extension View {
                     backgroundColor: .coreWhite
                 )
             )
+            
+        // MARK: - PlaceSearch
         
         case .placeSearch(let backAction):
             self.modifier(
@@ -368,6 +400,8 @@ extension View {
                 )
             )
             
+        // MARK: - MyPage
+            
         case .myPage(let backAction):
             self.modifier(
                 CustomNavigationBarModifier(
@@ -387,6 +421,9 @@ extension View {
                     backgroundColor: .gray100
                 )
             )
+            
+        // MARK: - MyPageEdit
+            
         case .myPageEdit(let title, let backAction):
             self.modifier(
                 CustomNavigationBarModifier(

--- a/Solply/Solply/Global/Modifier/CustomNavigationBarModifier.swift
+++ b/Solply/Solply/Global/Modifier/CustomNavigationBarModifier.swift
@@ -57,7 +57,6 @@ extension CustomNavigationBarModifier {
             
             Spacer()
         }
-        .ignoresSafeArea(edges: .bottom)
         .navigationBarHidden(true)
     }
     

--- a/Solply/Solply/Presentation/Archive/Archive/View/ArchiveView.swift
+++ b/Solply/Solply/Presentation/Archive/Archive/View/ArchiveView.swift
@@ -79,10 +79,10 @@ struct ArchiveView: View {
         }
         .frame(maxHeight: .infinity, alignment: .top)
         .customNavigationBar(.archive(backAction: appCoordinator.goBack))
+        .ignoresSafeArea(edges: .bottom)
         .onAppear {
             store.dispatch(.fetchPlaceThumbnail)
             store.dispatch(.fetchCourseThumbnail)
         }
     }
 }
-

--- a/Solply/Solply/Presentation/Archive/ArchiveList/View/ArchiveListView.swift
+++ b/Solply/Solply/Presentation/Archive/ArchiveList/View/ArchiveListView.swift
@@ -77,6 +77,7 @@ struct ArchiveListView: View {
             }
         }
         .customNavigationBar(.archiveList(title: town, backAction: appCoordinator.goBack))
+        .ignoresSafeArea(edges: .bottom)
         .onAppear {
             store.dispatch(.fetchPlaceList(townId: townId, isBookmarkSearch: true, mainTagId: nil, subTagAIdList: nil, subTagBIdList: nil))
             store.dispatch(.fetchCourseList(townId: townId, placeId: nil))

--- a/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
@@ -348,7 +348,7 @@ extension CourseDetailView {
                                         toastType: .withIconToast,
                                         message: "코스 안에 2개 이상의 장소가 남아있어야 해요.",
                                         buttonTitle: nil,
-                                        bottomPadding: 80.adjustedHeight
+                                        bottomPadding: 96.adjustedHeight
                                     )
                                 )
                             )

--- a/Solply/Solply/Presentation/MyPage/View/MyPageView.swift
+++ b/Solply/Solply/Presentation/MyPage/View/MyPageView.swift
@@ -44,6 +44,7 @@ struct MyPageView: View {
         }
         .background(Color(.gray100).ignoresSafeArea())
         .customNavigationBar(.myPage(backAction: appCoordinator.goBack))
+        .ignoresSafeArea(edges: .bottom)
     }
 }
 

--- a/Solply/Solply/Presentation/Place/PlaceDetail/Effect/PlaceDetailEffect.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/Effect/PlaceDetailEffect.swift
@@ -5,7 +5,7 @@
 //  Created by 김승원 on 7/16/25.
 //
 
-import UIKit
+import Foundation
 
 struct PlaceDetailEffect {
     private let courseService: CourseAPI

--- a/Solply/Solply/Presentation/Reports/Component/View/ReportsCompleteView.swift
+++ b/Solply/Solply/Presentation/Reports/Component/View/ReportsCompleteView.swift
@@ -1,0 +1,18 @@
+//
+//  ReportsCompleteView.swift
+//  Solply
+//
+//  Created by 김승원 on 9/25/25.
+//
+
+import SwiftUI
+
+struct ReportsCompleteView: View {
+    var body: some View {
+        Text("완료!!")
+    }
+}
+
+#Preview {
+    ReportsCompleteView()
+}

--- a/Solply/Solply/Presentation/Reports/Component/View/ReportsCompleteView.swift
+++ b/Solply/Solply/Presentation/Reports/Component/View/ReportsCompleteView.swift
@@ -9,7 +9,14 @@ import SwiftUI
 
 struct ReportsCompleteView: View {
     var body: some View {
-        Text("완료!!")
+        VStack(alignment: .center, spacing: 39.adjustedHeight) {
+            LottieView(jsonName: "finishOnboarding")
+                .frame(width: 230.adjustedWidth, height: 230.adjustedHeight)
+                
+            Text("소중한 제보 감사합니다!")
+                .applySolplyFont(.display_20_sb)
+        }
+        .background(.coreWhite)
     }
 }
 

--- a/Solply/Solply/Presentation/Reports/Effect/ReportsEffect.swift
+++ b/Solply/Solply/Presentation/Reports/Effect/ReportsEffect.swift
@@ -1,0 +1,22 @@
+//
+//  ReportsEffect.swift
+//  Solply
+//
+//  Created by 김승원 on 9/25/25.
+//
+
+import Foundation
+
+struct ReportsEffect {
+    // TODO: - Service 추후 추가 예정
+    
+}
+
+// MARK: - Functions
+
+extension ReportsEffect {
+    func waitForLottie() async -> ReportsAction {
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+        return .endLottie
+    }
+}

--- a/Solply/Solply/Presentation/Reports/Intent/ReportsAction.swift
+++ b/Solply/Solply/Presentation/Reports/Intent/ReportsAction.swift
@@ -11,4 +11,7 @@ enum ReportsAction {
     case selectReportsType(reportsType: ReportsType)
     case changeReportsStep(reportsStep: ReportsStep)
     case editReportsContent(reportsContent: String)
+    
+    case startLottie
+    case endLottie
 }

--- a/Solply/Solply/Presentation/Reports/Intent/ReportsStore.swift
+++ b/Solply/Solply/Presentation/Reports/Intent/ReportsStore.swift
@@ -9,12 +9,26 @@ import Foundation
 
 @MainActor
 final class ReportsStore: ObservableObject {
+    
     @Published private(set) var state = ReportsState()
+    private let effect = ReportsEffect()
     
     func dispatch(_ action: ReportsAction) {
         ReportsReducer.reduce(state: &state, action: action)
         
         switch action {
+            
+        case .changeReportsStep(let reportsStep):
+            if reportsStep == .reportsComplete {
+                dispatch(.startLottie)
+            }
+        
+        case .startLottie:
+            Task {
+                let result = await effect.waitForLottie()
+                dispatch(result)
+            }
+            
         default:
             break
         }

--- a/Solply/Solply/Presentation/Reports/State/ReportsReducer.swift
+++ b/Solply/Solply/Presentation/Reports/State/ReportsReducer.swift
@@ -18,6 +18,12 @@ enum ReportsReducer {
             
         case .editReportsContent(let reportsContent):
             state.reportsContent = reportsContent
+            
+        case .startLottie:
+            break
+            
+        case .endLottie:
+            state.shouldGoBack = true
         }
     }
 }

--- a/Solply/Solply/Presentation/Reports/State/ReportsState.swift
+++ b/Solply/Solply/Presentation/Reports/State/ReportsState.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct ReportsState {
-    var reportsStep: ReportsStep = .ReportsSelect
+    var reportsStep: ReportsStep = .reportsSelect
     var selectedReportsType: ReportsType?
     var reportsContent: String = ""
 }

--- a/Solply/Solply/Presentation/Reports/State/ReportsState.swift
+++ b/Solply/Solply/Presentation/Reports/State/ReportsState.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct ReportsState {
+    var shouldGoBack: Bool = false
     var reportsStep: ReportsStep = .reportsSelect
     var selectedReportsType: ReportsType?
     var reportsContent: String = ""

--- a/Solply/Solply/Presentation/Reports/View/ReportsView.swift
+++ b/Solply/Solply/Presentation/Reports/View/ReportsView.swift
@@ -86,7 +86,11 @@ extension ReportsView {
     }
     
     private var reportsCompleteView: some View {
-        ReportsCompleteView()
+        Group {
+            if store.state.reportsStep == .reportsComplete {
+                ReportsCompleteView()
+            }
+        }
     }
 }
 

--- a/Solply/Solply/Presentation/Reports/View/ReportsView.swift
+++ b/Solply/Solply/Presentation/Reports/View/ReportsView.swift
@@ -48,8 +48,14 @@ struct ReportsView: View {
                 }
             )
         )
+        .ignoresSafeArea(.keyboard)
         .onTapGesture {
             hideKeyboard()
+        }
+        .onChange(of: store.state.shouldGoBack) { _, newValue in
+            if newValue {
+                appCoordinator.goBack()
+            }
         }
     }
 }

--- a/Solply/Solply/Presentation/Reports/View/ReportsView.swift
+++ b/Solply/Solply/Presentation/Reports/View/ReportsView.swift
@@ -14,21 +14,17 @@ struct ReportsView: View {
     @EnvironmentObject var appCoordinator: AppCoordinator
     @StateObject private var store = ReportsStore()
     
+    private let screenWidth: CGFloat = UIScreen.main.bounds.width
+    
     // MARK: - Body
     
     var body: some View {
         ZStack(alignment: .center) {
-            switch store.state.reportsStep {
-            case .ReportsSelect:
-                reportsSelectView
-                
-            case .ReportsDetail:
-                reportsDetailView
-                
-            case .ReportsComplete:
-                // TODO: - ReportsCompleteView 연결
-                Text("ReportsComplete")
-            }
+            reportsSelectView
+                .offset(x: calculateScreenOffset(.reportsSelect))
+
+            reportsDetailView
+                .offset(x: calculateScreenOffset(.reportsDetail))
         }
         .background(.coreWhite)
         .customNavigationBar(
@@ -51,7 +47,9 @@ extension ReportsView {
         ReportsSelectView(selectedReportsType: store.state.selectedReportsType) { reportsType in
             store.dispatch(.selectReportsType(reportsType: reportsType))
         } nextAction: {
-            store.dispatch(.changeReportsStep(reportsStep: .ReportsDetail))
+            withAnimation(.easeInOut(duration: 0.3)) {
+                store.dispatch(.changeReportsStep(reportsStep: .reportsDetail))
+            }
         }
     }
     
@@ -61,7 +59,7 @@ extension ReportsView {
         } onPhotosSelected: { imageKeys in
             // TODO: - ReportsState 연결
         } onCompleteAction: {
-            store.dispatch(.changeReportsStep(reportsStep: .ReportsComplete))
+            // TODO: - 제보 완료 뷰 연결
         }
     }
 }
@@ -70,11 +68,26 @@ extension ReportsView {
 
 extension ReportsView {
     private func backAction() {
-        if store.state.reportsStep == .ReportsDetail {
-            store.dispatch(.changeReportsStep(reportsStep: .ReportsSelect))
+        if store.state.reportsStep == .reportsDetail {
+            withAnimation(.easeIn(duration: 0.2)) {
+                store.dispatch(.changeReportsStep(reportsStep: .reportsSelect))
+            }
         } else {
             appCoordinator.goBack()
         }
+    }
+    
+    private func calculateScreenOffset(_ reportsStep: ReportsStep) -> CGFloat {
+        var offset: CGFloat = 0
+        
+        switch reportsStep {
+        case .reportsSelect:
+            offset = store.state.reportsStep == .reportsSelect ? 0 : -screenWidth
+        case .reportsDetail:
+            offset = store.state.reportsStep == .reportsDetail ? 0 : screenWidth
+        }
+        
+        return offset
     }
 }
 

--- a/Solply/Solply/Presentation/Reports/View/ReportsView.swift
+++ b/Solply/Solply/Presentation/Reports/View/ReportsView.swift
@@ -19,16 +19,30 @@ struct ReportsView: View {
     // MARK: - Body
     
     var body: some View {
-        ZStack(alignment: .center) {
+        ZStack {
             reportsSelectView
-                .offset(x: calculateScreenOffset(.reportsSelect))
-
+                .offset(
+                    x: store.state.reportsStep == .reportsSelect
+                    ? 0 : store.state.reportsStep == .reportsDetail
+                    ? -screenWidth : -screenWidth
+                )
+            
             reportsDetailView
-                .offset(x: calculateScreenOffset(.reportsDetail))
+                .offset(
+                    x: store.state.reportsStep == .reportsSelect
+                    ? screenWidth : store.state.reportsStep == .reportsDetail
+                    ? 0 : -screenWidth
+                )
+            
+            reportsCompleteView
+                .offset(
+                    x: store.state.reportsStep == .reportsComplete ? 0 : screenWidth
+                )
         }
         .background(.coreWhite)
         .customNavigationBar(
             .reports(
+                reportStep: store.state.reportsStep,
                 backAction: {
                     backAction()
                 }
@@ -59,8 +73,14 @@ extension ReportsView {
         } onPhotosSelected: { imageKeys in
             // TODO: - ReportsState 연결
         } onCompleteAction: {
-            // TODO: - 제보 완료 뷰 연결
+            withAnimation(.easeInOut(duration: 0.3)) {
+                store.dispatch(.changeReportsStep(reportsStep: .reportsComplete))
+            }
         }
+    }
+    
+    private var reportsCompleteView: some View {
+        ReportsCompleteView()
     }
 }
 
@@ -75,19 +95,6 @@ extension ReportsView {
         } else {
             appCoordinator.goBack()
         }
-    }
-    
-    private func calculateScreenOffset(_ reportsStep: ReportsStep) -> CGFloat {
-        var offset: CGFloat = 0
-        
-        switch reportsStep {
-        case .reportsSelect:
-            offset = store.state.reportsStep == .reportsSelect ? 0 : -screenWidth
-        case .reportsDetail:
-            offset = store.state.reportsStep == .reportsDetail ? 0 : screenWidth
-        }
-        
-        return offset
     }
 }
 

--- a/Solply/Solply/Presentation/TabBar/TabBarView.swift
+++ b/Solply/Solply/Presentation/TabBar/TabBarView.swift
@@ -72,6 +72,7 @@ extension TabBarView {
             )
             .visible(appCoordinator.selectedTab == .course)
         }
+        .ignoresSafeArea(edges: .bottom)
     }
     
     private var tabBar: some View {


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 제보하기 뷰 UI를 마저 구현했습니다.
- 화면 전환 애니메이션을 추가했습니다.
- 로띠 뷰 추가했습니다.
- `navigationBar`에 `ignoreSafeArea`가 적용되어있어 전체적으로 `safeArea`가 적용되지 않던 문제를 해결했습니다.

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| 화면 전환 | <img src = "https://github.com/user-attachments/assets/5ece61ae-b365-4df5-a2ec-6067ec1ac317" width ="250"> | <img src = "https://github.com/user-attachments/assets/22259aea-a355-4e5b-80f6-49ae8108793a" width ="250"> |
| 상태 저장 | <img src = "https://github.com/user-attachments/assets/67a01258-d76d-49a5-95fb-6ec526d3c885" width ="250"> | <img src = "https://github.com/user-attachments/assets/0ac66256-6dca-4848-8135-70054c70b063" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### safeArea수정
- `CustomNavigationBar`에 `.ignoreSafeArea(edges: .bottom)`를 제가 넣어놨더라고요 요놈 때문에 bottom쪽 SafeArea가 적용되지 않았습니다. 이거 수정함!
```Swift
extension CustomNavigationBarModifier {
    private func defaultNavigationBar(_ content: Content) -> some View {
        VStack(spacing: 0) {
            ZStack(alignment: .center) {
                HStack(spacing: 0) {
                    self.leftView?()
                    
                    Spacer()
                    
                    self.rightView?()
                }
                
                self.centerView?()
                
            }
            .padding(.horizontal, 16.adjustedWidth)
            .padding(.vertical, 16.adjustedHeight)
            .background(backgroundColor)
            
            content
            
            Spacer()
        }
        .ignoresSafeArea(edges: .bottom) // <- 이거 지웠어요
        .navigationBarHidden(true)
    }
```
- 그에 따라 `bottom`쪽 `ignoreSafeArea` 해줘야하는 뷰들에 다 코드 추가해 놨아요

### ReportsView에 화면전환 애니메이션 구현, 상태 저장
```Swift
ZStack {
    reportsSelectView
        .offset(
            x: store.state.reportsStep == .reportsSelect
            ? 0 : store.state.reportsStep == .reportsDetail
            ? -screenWidth : -screenWidth
        )
    
    reportsDetailView
        .offset(
            x: store.state.reportsStep == .reportsSelect
            ? screenWidth : store.state.reportsStep == .reportsDetail
            ? 0 : -screenWidth
        )
    
    reportsCompleteView
        .offset(
            x: store.state.reportsStep == .reportsComplete ? 0 : screenWidth
        )
}
```
첨에 `Group`으로 묶고 `if`문으로 처리했는데요, 그렇게 하니까 뷰들 상태 저장이 안 되더라고요
(일반 뷰는 상태 저장이 필요 없겠지만, 뭔가 이 제보 플로우에서는 사용자가 뒤로갔다가 앞으로 갔다가 할 가능성이 있어서 상태 저장이 필요해 보였습니다.)
그래서 방법을 바꿔서 현재 `TabBarView` 처럼 `ZStack`에 3개 `subView`를 배치하고 `offset`으로 관리하여 애니메이션도 챙기고 뷰들이 상태를 저장할 수 있게 했어요~

### 문제 발생!
```Swift
// ReportsView.swift

private var reportsCompleteView: some View {
    Group {
        if store.state.reportsStep == .reportsComplete {
            ReportsCompleteView()
        }
    }
}
```
현재 제보뷰에 로띠뷰가 이렇게 if문으로 감싸져 있는데요 그 이유가..
원래는 그냥 바로 `ReportsCompleteView()`만 있었는데 이렇게 선언하니까 `ReportsView()`가 메모리에 올라감과 동시에 `ReportsCompleteView()`도 올라가서 로띠가 원하는대로 재생이 되지 않았습니다.
**(이미 돌아가는 상태라 로띠뷰로 이동헀을 때 처음부터 나오지 않는 버그 발생)**
그래서 `if`문으로 감싸서 `store.state.reportsStep`이 `.reportsComplete`일 때 `ReportsCompleteView`를 메모리를 올려 로띠가 제대로 나오게 했어요 (더 좋은 방법이 있다면 추천점..)

ps. 근데 이유는 모르겠는데 이렇게 하니까 또 `offset` 애니메이션이 적용이 안 되는 거 같더라고요.. 로띠뷰가 오른쪽에서 왼쪽으로 밀려나와야하는데  가만히 있슴! ㅠㅠ BUT, 일단 그렇게 신경쓰이지 않아서 pr 올립니다ㅏㅏ

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #256
