### PR TITLE
[fix/#293] 캐러셀 버그 수정

### DIFF
--- a/Solply/Solply/Presentation/Place/Component/TodayPlaceRecommendCarousel.swift
+++ b/Solply/Solply/Presentation/Place/Component/TodayPlaceRecommendCarousel.swift
@@ -36,32 +36,34 @@ struct TodayPlaceRecommendCarousel: View {
 
     var body: some View {
         ZStack {
-            ForEach(-2...2, id: \.self) { offsetIndex in
-                let index =
+            if !store.state.placeRecommendItems.isEmpty {
+                ForEach(-2...2, id: \.self) { offsetIndex in
+                    let index =
                     (currentIndex + offsetIndex + store.state.placeRecommendItems.count)
                     % store.state.placeRecommendItems.count
-                let baseX = CGFloat(offsetIndex) * cardOffset
-                let totalOffset = baseX + dragOffset
-
-                let distanceFromCenter = abs(totalOffset)
-                let scale = max(0.75, 1.0 - (distanceFromCenter / (cardOffset * 2)))
-
-                TodayPlaceRecommendCard(
-                    thumbnailImageUrl: store.state.placeRecommendItems[index].thumbnailUrl,
-                    category: store.state.placeRecommendItems[index].category,
-                    title: store.state.placeRecommendItems[index].title,
-                    introduction: store.state.placeRecommendItems[index].introduction
-                ) {
-                    appCoordinator.navigate(
-                        to: .placeDetail(
-                            townId: townId,
-                            placeId: store.state.placeRecommendItems[index].id
+                    let baseX = CGFloat(offsetIndex) * cardOffset
+                    let totalOffset = baseX + dragOffset
+                    
+                    let distanceFromCenter = abs(totalOffset)
+                    let scale = max(0.75, 1.0 - (distanceFromCenter / (cardOffset * 2)))
+                    
+                    TodayPlaceRecommendCard(
+                        thumbnailImageUrl: store.state.placeRecommendItems[index].thumbnailUrl,
+                        category: store.state.placeRecommendItems[index].category,
+                        title: store.state.placeRecommendItems[index].title,
+                        introduction: store.state.placeRecommendItems[index].introduction
+                    ) {
+                        appCoordinator.navigate(
+                            to: .placeDetail(
+                                townId: townId,
+                                placeId: store.state.placeRecommendItems[index].id
+                            )
                         )
-                    )
+                    }
+                    .frame(width: cardWidth, height: cardWidth)
+                    .scaleEffect(scale)
+                    .offset(x: totalOffset)
                 }
-                .frame(width: cardWidth, height: cardWidth)
-                .scaleEffect(scale)
-                .offset(x: totalOffset)
             }
         }
         .frame(height: 240.adjustedHeight)


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 캐러셀 계산하는 과정에서 0으로 나눠주는 부분이 있는데, 그 부분에서 크래시가 났어요.
- 분기처리가 다 안된 것 같아서 placeRecommendItems가 비어있지 않은 경우에만 캐러셀을 띄울 수 있도록 수정했습니다.

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #293 
