### PR TITLE
[fix/#305] 장소 제보하기/등록하기 QA TextEditor 키보드 수정사항 반영

### DIFF
--- a/Solply/Solply/Presentation/Register/View/RegisterView.swift
+++ b/Solply/Solply/Presentation/Register/View/RegisterView.swift
@@ -35,8 +35,8 @@ struct RegisterView: View {
                 }
             }
             .scrollDismissesKeyboard(.interactively)
-            .onChange(of: isFocused) { _, focused in
-                if focused {
+            .onChange(of: isFocused) { _, isFocused in
+                if isFocused {
                     withAnimation(.easeOut(duration: 0.3)) {
                         proxy.scrollTo("textEditor", anchor: .bottom)
                     }


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- `TextEditor`를 눌렀을 떄 키보드에 `TextEditor`가 가리지 않도록 자동 스크롤이 되게 수정했습니다.

|    구현 내용    |   iPhone 13 mini   |   iPhone 17 pro   |
| :-------------: | :----------: | :----------: |
| A 기능 | <img src = "https://github.com/user-attachments/assets/5d9c6b2e-86d9-45a6-aef0-e1442e0adbb4" width ="250"> | <img src = "https://github.com/user-attachments/assets/1331efa2-9c97-4dff-a99e-c50e1f61d76f" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### FocusState에 대한 설명 / 생각

원래 `TextEditor`를 눌렀을 떄 키보드에 가리지 않도록 뷰를 올려주는 기능이 있는데요
찾아보니까 `ScrollView`위에 `TextEditor`를 올린 상태에서는 적용이 안된다는 글이 엄청 많더라고요 (나만 겪는 문제가 아니었음)
=> 그래서 포커스 상태에 따라 `ScrollViewReader`를 사용해서 최하단으로 강제 스크롤하는 방식으로 구현했어요

```Swift
// RegisterView.swift

// MARK: - Properties

@EnvironmentObject private var appCoordinator: AppCoordinator
@FocusState private var isFocused: Bool // <- 이걸로 focus상태를 체크
@StateObject private var store = RegisterStore()

// MARK: - Body

var body: some View {
    ScrollViewReader { proxy in
        ScrollView(.vertical) {
            VStack(alignment: .center, spacing: 40.adjustedHeight) {
                searchPlace
                
                selectMainTagType
                
                selectExtraFeatures
                    .focused($isFocused) // <- 이 TextEditor가 포커스 될 때
                
                Rectangle()
                    .frame(height: 156.adjustedHeight)
                    .foregroundStyle(.clear)
                    .id("textEditor")
            }
        }
        .scrollDismissesKeyboard(.interactively) // <- 스크롤 할 때 키보드 내림
        .onChange(of: isFocused) { _, isFocused in
            if isFocused {
                withAnimation(.easeOut(duration: 0.3)) {
                    proxy.scrollTo("textEditor", anchor: .bottom) // <- 최하단으로 스크롤하게
                }
            }
        }
    }
```
`ScrollViewReader` + `id` + `focusState`를 이용해서 젤 아래로 스크롤되게 했어요

#### 💭 여기서 고민한 점
`FocusState`는 어디서 관리하는 것이 맞나?
처음에는 이것도 뷰의 상태라고 생각해서 `State`에서 관리하는 게 맞다고 생각을 했는데요,

결론부터 말하자면, 일단 `State`에는 순수데이터만 포함되어야 하기 때문에 들어갈 수 없고,
만약 `State`에서 보관한다 해도 컴파일은 되는데, 동작하지 않더라고요
(`SwiftUI` 내부적으로 `View`의 포커스 상태를 추적하기 위한 래퍼라 `ObservableObject`로 가져가면 `SwiftUI`가 `lifeCyle`을 보장하지 못한다고 합니다...)

#### 💭 그러면 View에서 FocusState를 보관하고 나머지는 State, action으로 관리하면 되지 않을까?
그렇게 시도를 했는데, 지금 상태에서는 `View`를 다시 그리기보단, `Scroll`위치만 조정하면 되기 떄문에
더 복잡해지기만 하고, 굳이 싶더라고요. 그래서 이런 `Focus`상태는 View에서 관리하는 게 맞다고 생각합니닷
(만약 이 포커스 상태에 따라 뷰를 다시 그려야 한다면 그 부분은 MVI 철학에 맞게 처리하는 것이 맞겠쬬)

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #305 

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

https://green1229.tistory.com/278

https://developer.apple.com/documentation/swiftui/focusstate

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
솔플리 파이팅 아자스
