### PR TITLE
[feat/#349] Logout API 연동

### DIFF
--- a/Solply/Solply/Network/API/AuthAPI.swift
+++ b/Solply/Solply/Network/API/AuthAPI.swift
@@ -19,4 +19,7 @@ protocol AuthAPI {
     
     /// 사용자 로그인 정보 조회
     func fetchLoginInformation() async throws -> BaseResponseBody<LoginInformationResponseDTO>
+    
+    /// 로그아웃
+    func logout() async throws -> BaseResponseBody<EmptyResponseDTO>
 }

--- a/Solply/Solply/Network/Service/AuthService.swift
+++ b/Solply/Solply/Network/Service/AuthService.swift
@@ -30,4 +30,8 @@ extension AuthService: AuthAPI {
     func fetchLoginInformation() async throws -> BaseResponseBody<LoginInformationResponseDTO> {
         return try await self.request(with: .fetchLoginInformation)
     }
+    
+    func logout() async throws -> BaseResponseBody<EmptyResponseDTO> {
+        return try await self.request(with: .logout)
+    }
 }

--- a/Solply/Solply/Network/TargetType/AuthTargetType.swift
+++ b/Solply/Solply/Network/TargetType/AuthTargetType.swift
@@ -13,6 +13,7 @@ enum AuthTargetType {
     case submitLogin(provider: String, request: AuthLoginRequestDTO)
     case refreshToken(refreshToken: String)
     case fetchLoginInformation
+    case logout
 }
 
 extension AuthTargetType: BaseTargetType {
@@ -21,6 +22,7 @@ extension AuthTargetType: BaseTargetType {
         case .submitLogin: return .contentTypeJSON
         case .refreshToken(let refreshToken): return .refreshToken(refreshToken)
         case .fetchLoginInformation: return .contentTypeJSON
+        case .logout: return .contentTypeJSON
         }
     }
     
@@ -29,6 +31,7 @@ extension AuthTargetType: BaseTargetType {
         case .submitLogin(let provider, _): return "/auth/social/\(provider)/login"
         case .refreshToken: return "/auth/refresh"
         case .fetchLoginInformation: return "/auth/login-info"
+        case .logout: return "/auth/logout"
         }
     }
     
@@ -37,6 +40,7 @@ extension AuthTargetType: BaseTargetType {
         case .submitLogin: return .post
         case .refreshToken: return .post
         case .fetchLoginInformation: return .get
+        case .logout: return .delete
         }
     }
     
@@ -45,6 +49,7 @@ extension AuthTargetType: BaseTargetType {
         case .submitLogin(_, let request): return .requestJSONEncodable(request)
         case .refreshToken: return .requestPlain
         case .fetchLoginInformation: return .requestPlain
+        case .logout: return .requestPlain
         }
     }
 }

--- a/Solply/Solply/Presentation/MyPage/MyPage/Effect/MyPageEffect.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPage/Effect/MyPageEffect.swift
@@ -62,4 +62,17 @@ extension MyPageEffect {
             return .fetchLoginInformationFailed(error: .unknownError)
         }
     }
+    
+    func logout() async -> MyPageAction {
+        do {
+            _ = try await authService.logout()
+            
+            return .logoutSuccess
+            
+        } catch let error as NetworkError {
+            return .logoutFailed(error: error)
+        } catch {
+            return .logoutFailed(error: .unknownError)
+        }
+    }
 }

--- a/Solply/Solply/Presentation/MyPage/MyPage/Intent/MyPageAction.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPage/Intent/MyPageAction.swift
@@ -14,10 +14,13 @@ enum MyPageAction {
     
     case editProfileTapped
     case customerCenterTapped
-    case logoutTapped
     case deleteAccountTapped
     
     case fetchLoginInformation
     case fetchLoginInformationSuccess(loginInformation: SocialLoginType?)
     case fetchLoginInformationFailed(error: NetworkError)
+    
+    case logout
+    case logoutSuccess
+    case logoutFailed(error: NetworkError)
 }

--- a/Solply/Solply/Presentation/MyPage/MyPage/Intent/MyPageStore.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPage/Intent/MyPageStore.swift
@@ -31,6 +31,12 @@ final class MyPageStore: ObservableObject {
                 let result = await effect.fetchLoginInformation()
                 dispatch(result)
             }
+            
+        case .logout:
+            Task {
+                let result = await effect.logout()
+                dispatch(result)
+            }
 
         default:
             break

--- a/Solply/Solply/Presentation/MyPage/MyPage/State/MyPageReducer.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPage/State/MyPageReducer.swift
@@ -28,10 +28,6 @@ enum MyPageReducer {
             // TODO: 고객센터 화면/외부 링크 이동
             break
             
-        case .logoutTapped:
-            // TODO: 로그아웃 처리 + 로그인 화면 이동
-            break
-            
         case .deleteAccountTapped:
             // TODO: 탈퇴 처리 + 앱 상태 초기화
             break
@@ -46,6 +42,18 @@ enum MyPageReducer {
             state.error = error
             print(error)
             break
+            
+        case .logout:
+            break
+            
+        case .logoutSuccess:
+            TokenManager.shared.clearTokens()
+            state.shouldChangeRoot = true
+            break
+            
+        case .logoutFailed(let error):
+            state.error = error
+            print(error)
         }
     }
 }

--- a/Solply/Solply/Presentation/MyPage/MyPage/State/MyPageState.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPage/State/MyPageState.swift
@@ -12,4 +12,6 @@ struct MyPageState {
     var registeredPlaces: [UserPlace] = []
     var error: NetworkError?
     var loginInformation: SocialLoginType?
+    
+    var shouldChangeRoot: Bool = false
 }

--- a/Solply/Solply/Presentation/MyPage/MyPage/View/MyPageSettings.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPage/View/MyPageSettings.swift
@@ -112,8 +112,6 @@ struct MyPageSettings: View {
     
     private func performLogout() {
         onTapLogout?()
-        TokenManager.shared.clearTokens()
-        appCoordinator.changeRoot(to: .auth)
     }
 }
 

--- a/Solply/Solply/Presentation/MyPage/MyPage/View/MyPageView.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPage/View/MyPageView.swift
@@ -38,7 +38,7 @@ struct MyPageView: View {
                         loginProvider: store.state.loginInformation,
                         appVersion: "v" + (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"),
                         onTapCustomerCenter: { store.dispatch(.customerCenterTapped) },
-                        onTapLogout: { store.dispatch(.logoutTapped) },
+                        onTapLogout: { store.dispatch(.logout) },
                         onTapDeleteAccount: { store.dispatch(.deleteAccountTapped)
                             appCoordinator.navigate(to: .withdraw)
                         }
@@ -47,6 +47,11 @@ struct MyPageView: View {
                 }
                 Spacer()
                     .frame(height: 30.adjustedHeight)
+            }
+        }
+        .onChange(of: store.state.shouldChangeRoot) { _, newValue in
+            if newValue {
+                appCoordinator.changeRoot(to: .auth)
             }
         }
         .background(Color(.gray100).ignoresSafeArea())


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 로그아웃 기존 토큰만 제거하는 방식에서 `Logout API`까지 추가로 연동했습니다.

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### MyPage에서 AuthView로 넘기는 방법!
```Swift
// MyPageState.swift

struct MyPageState {
    var user: UserInformation?
    var registeredPlaces: [UserPlace] = []
    var error: NetworkError?
    var loginInformation: SocialLoginType?
    
    var shouldChangeRoot: Bool = false // <- 탈퇴도 요거 toggle 시켜주면 댐
}
```

```Swift
// MyPageReducer.swift

case .logout:
    break
    
case .logoutSuccess:
    TokenManager.shared.clearTokens() // <- 로그아웃시 토큰 지우고
    state.shouldChangeRoot = true // <- 아까 그 변수 true로 토글시키면 댐
    break
    
case .logoutFailed(let error):
    state.error = error
    print(error)
}
```

```Swift
// MyPageView.swift

.onChange(of: store.state.shouldChangeRoot) { _, newValue in
    if newValue {
        appCoordinator.changeRoot(to: .auth)
    }
}
```
그럼 뷰에서 `.onChange`로 처리

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #349 
