### PR TITLE
[fix/#356] iOS26 버전에서 Drag&Drop 안 되던 버그 수정  (QA 반영)

### DIFF
--- a/Solply/Solply/Global/Util/HapticManager.swift
+++ b/Solply/Solply/Global/Util/HapticManager.swift
@@ -1,0 +1,28 @@
+//
+//  HapticManager.swift
+//  Solply
+//
+//  Created by 김승원 on 12/12/25.
+//
+
+import SwiftUI
+
+final class HapticManager {
+    
+    static let shared = HapticManager()
+    private init() {}
+    
+    /// 지정한 타입의 알림 햅틱을 발생시킵니다.
+    /// - Parameter type: `.success`, `.warning`, `.error`
+    func notification(type: UINotificationFeedbackGenerator.FeedbackType) {
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(type)
+    }
+    
+    /// 지정한 타입의 임팩트 햅틱을 발생시킵니다.
+    /// - Parameter style: `.light`, `.medium`, `.heavy`, `.soft`, `.rigid`
+    func impact(style: UIImpactFeedbackGenerator.FeedbackStyle) {
+        let generator = UIImpactFeedbackGenerator(style: style)
+        generator.impactOccurred()
+    }
+}

--- a/Solply/Solply/Presentation/Course/CourseDetail/DragDrop/DeleteDropModifier.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/DragDrop/DeleteDropModifier.swift
@@ -39,13 +39,9 @@ struct DeleteDropModifier: ViewModifier {
                     },
                     onEntered: {
                         onEntered?()
-                        let generator = UIImpactFeedbackGenerator(style: .medium)
-                        generator.impactOccurred()
                     },
                     onExited: {
                         onExited?()
-                        let generator = UIImpactFeedbackGenerator(style: .medium)
-                        generator.impactOccurred()
                     }
                 )
             )

--- a/Solply/Solply/Presentation/Course/CourseDetail/DragDrop/DragDropModifier.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/DragDrop/DragDropModifier.swift
@@ -15,6 +15,7 @@ struct DragDropModifier: ViewModifier {
     private let startDragging: (() -> Void)?
     private let whileDragging: (() -> Void)?
     private let endDragging: (() -> Void)?
+    private let endWithoutDragging: (() -> Void)?
     
     // MARK: - Initializer
     
@@ -22,12 +23,14 @@ struct DragDropModifier: ViewModifier {
         isEditing: Bool,
         startDragging: (() -> Void)?,
         whileDragging: (() -> Void)?,
-        endDragging: (() -> Void)?
+        endDragging: (() -> Void)?,
+        endWithoutDragging: (() -> Void)?
     ) {
         self.isEditing = isEditing
         self.startDragging = startDragging
         self.whileDragging = whileDragging
         self.endDragging = endDragging
+        self.endWithoutDragging = endWithoutDragging
     }
     
     // MARK: - Body
@@ -35,6 +38,11 @@ struct DragDropModifier: ViewModifier {
     func body(content: Content) -> some View {
         if isEditing {
             content
+                .overlay(
+                    LongPressRecognizerView {
+                        endWithoutDragging?()
+                    }
+                )
                 .onDrag {
                     guard isEditing else { return NSItemProvider() }
                     
@@ -83,14 +91,16 @@ extension View {
         isEditing: Bool,
         startDragging: (() -> Void)?,
         whileDragging: (() -> Void)?,
-        endDragging: (() -> Void)?
+        endDragging: (() -> Void)?,
+        endWithoutDragging: (() -> Void)?
     ) -> some View {
         self.modifier(
             DragDropModifier(
                 isEditing: isEditing,
                 startDragging: startDragging,
                 whileDragging: whileDragging,
-                endDragging: endDragging
+                endDragging: endDragging,
+                endWithoutDragging: endWithoutDragging
             )
         )
     }

--- a/Solply/Solply/Presentation/Course/CourseDetail/DragDrop/DragDropModifier.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/DragDrop/DragDropModifier.swift
@@ -38,11 +38,7 @@ struct DragDropModifier: ViewModifier {
                 .onDrag {
                     guard isEditing else { return NSItemProvider() }
                     
-                    let generator = UIImpactFeedbackGenerator(style: .light)
-                    generator.impactOccurred()
-                    
                     startDragging?()
-                    
                     return NSItemProvider()
                 }
                 .onDrop(

--- a/Solply/Solply/Presentation/Course/CourseDetail/DragDrop/LongPressRecognizerView.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/DragDrop/LongPressRecognizerView.swift
@@ -1,0 +1,130 @@
+//
+//  LongPressRecognizerView.swift
+//  Solply
+//
+//  Created by 김승원 on 12/12/25.
+//
+
+import SwiftUI
+
+struct LongPressRecognizerView: UIViewRepresentable {
+    
+    // MARK: - Properties
+    
+    let minimumPressDuration: TimeInterval
+    let allowableMovement: CGFloat
+    let onLongPress: (() -> Void)?
+    
+    // MARK: - Initializer
+    
+    init(
+        minimumPressDuration: TimeInterval = 0.1,
+        allowableMovement: CGFloat = 10,
+        onLongPress: (() -> Void)? = nil
+    ) {
+        self.minimumPressDuration = minimumPressDuration
+        self.allowableMovement = allowableMovement
+        self.onLongPress = onLongPress
+    }
+    
+    // MARK: - Functions
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView(frame: .zero)
+        view.backgroundColor = .clear
+        view.isUserInteractionEnabled = true
+
+        let longPressGesture = UILongPressGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handleLongPress)
+        )
+        
+        longPressGesture.minimumPressDuration = minimumPressDuration
+        longPressGesture.cancelsTouchesInView = false
+        longPressGesture.delaysTouchesBegan = false
+        longPressGesture.delaysTouchesEnded = false
+        longPressGesture.delegate = context.coordinator
+        
+        view.addGestureRecognizer(longPressGesture)
+
+        context.coordinator.gesture = longPressGesture
+        context.coordinator.hostView = view
+
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) { }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+}
+
+// MARK: - Coordinator
+
+extension LongPressRecognizerView {
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        
+        // MARK: - Properties
+        
+        private var beganLocation: CGPoint?
+        private var movedTooFar = false
+
+        weak var gesture: UILongPressGestureRecognizer?
+        weak var hostView: UIView?
+        
+        var parent: LongPressRecognizerView
+        
+        // MARK: - Initializer
+
+        init(_ parent: LongPressRecognizerView) {
+            self.parent = parent
+        }
+        
+        // MARK: - Functions
+
+        @objc
+        func handleLongPress(_ longPressGesture: UILongPressGestureRecognizer) {
+            guard let host = hostView else { return }
+            let location = longPressGesture.location(in: host)
+
+            switch longPressGesture.state {
+            case .began:
+                beganLocation = location
+                movedTooFar = false
+                
+            case .changed:
+                if let start = beganLocation {
+                    let dx = location.x - start.x
+                    let dy = location.y - start.y
+                    let distance = sqrt(dx*dx + dy*dy)
+                    if distance > parent.allowableMovement {
+                        movedTooFar = true
+                    }
+                }
+                
+            case .ended:
+                if movedTooFar == false {
+                    parent.onLongPress?()
+                }
+                
+                beganLocation = nil
+                movedTooFar = false
+                
+            case .cancelled, .failed:
+                beganLocation = nil
+                movedTooFar = false
+                
+            default:
+                break
+            }
+        }
+
+        func gestureRecognizer(
+            _ gestureRecognizer: UIGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+            return true
+        }
+    }
+}

--- a/Solply/Solply/Presentation/Course/CourseDetail/Intent/CourseDetailAction.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/Intent/CourseDetailAction.swift
@@ -24,6 +24,8 @@ enum CourseDetailAction {
     case endWithoutDragging
     
     case deletePlace
+    case deletePlaceFailed
+    
     case droppedInDeleteZone
     case draggedInDeleteZone
     case draggedOutDeleteZone

--- a/Solply/Solply/Presentation/Course/CourseDetail/Intent/CourseDetailAction.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/Intent/CourseDetailAction.swift
@@ -21,6 +21,8 @@ enum CourseDetailAction {
     case startDragging(draggedPlace: PlaceDetailInCourse)
     case whileDragging(destination: PlaceDetailInCourse)
     case endDragging
+    case endWithoutDragging
+    
     case deletePlace
     case droppedInDeleteZone
     case draggedInDeleteZone

--- a/Solply/Solply/Presentation/Course/CourseDetail/Intent/CourseDetailStore.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/Intent/CourseDetailStore.swift
@@ -46,6 +46,8 @@ final class CourseDetailStore: ObservableObject {
                         )
                     )
                 )
+                
+                self.dispatch(.deletePlaceFailed)
             }
             
         case .startEditing:

--- a/Solply/Solply/Presentation/Course/CourseDetail/State/CourseDetailReducer.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/State/CourseDetailReducer.swift
@@ -86,10 +86,16 @@ enum CourseDetailReducer {
             
             if let index = state.places.firstIndex(of: draggedPlace) {
                 state.places.remove(at: index)
-                state.canDelete = false
-                state.draggedPlace = nil
             }
             
+            state.draggedPlace = nil
+            state.canDelete = false
+            state.isInDeleteZone = false
+            
+        case .deletePlaceFailed:
+            state.dragDropState = .completed
+            state.draggedPlace = nil
+            state.canDelete = false
             state.isInDeleteZone = false
             
         case .droppedInDeleteZone:

--- a/Solply/Solply/Presentation/Course/CourseDetail/State/CourseDetailReducer.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/State/CourseDetailReducer.swift
@@ -74,6 +74,12 @@ enum CourseDetailReducer {
             state.canDelete = false
             state.isInDeleteZone = false
             
+        case .endWithoutDragging:
+            state.dragDropState = .prepared
+            state.draggedPlace = nil
+            state.canDelete = false
+            state.isInDeleteZone = false
+            
         case .deletePlace:
             guard let draggedPlace = state.draggedPlace else { return }
             state.dragDropState = .completed

--- a/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
@@ -233,16 +233,17 @@ extension CourseDetailView {
                     )
                 }
             }
-            .simultaneousGesture(
-                DragGesture(minimumDistance: 0)
-                    .onChanged { _ in
-                        
-                    }
-                    .onEnded { _ in
-                        
-                        store.dispatch(.endDragging)
-                    }
-            )
+            // TODO: - 드래그앤 드롭 버그 생기는 부분
+//            .simultaneousGesture(
+//                DragGesture(minimumDistance: 0)
+//                    .onChanged { _ in
+//                        
+//                    }
+//                    .onEnded { _ in
+//                        
+//                        store.dispatch(.endDragging)
+//                    }
+//            )
             .animation(.easeInOut(duration: 0.1), value: store.state.focusedPlaceIndex)
             .padding(.bottom, 35.adjustedHeight)
             .padding(.horizontal, 20.adjustedWidth)

--- a/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
+++ b/Solply/Solply/Presentation/Course/CourseDetail/View/CourseDetailView.swift
@@ -221,6 +221,10 @@ extension CourseDetailView {
                         isEditing: store.state.isEditing,
                         startDragging: {
                             store.dispatch(.startDragging(draggedPlace: place))
+                            
+                            if store.state.dragDropState == .dragging {
+                                HapticManager.shared.impact(style: .medium)
+                            }
                         },
                         whileDragging: {
                             withAnimation(.interactiveSpring) {
@@ -229,21 +233,13 @@ extension CourseDetailView {
                         },
                         endDragging: {
                             store.dispatch(.endDragging)
+                        },
+                        endWithoutDragging: {
+                            store.dispatch(.endWithoutDragging)
                         }
                     )
                 }
             }
-            // TODO: - 드래그앤 드롭 버그 생기는 부분
-//            .simultaneousGesture(
-//                DragGesture(minimumDistance: 0)
-//                    .onChanged { _ in
-//                        
-//                    }
-//                    .onEnded { _ in
-//                        
-//                        store.dispatch(.endDragging)
-//                    }
-//            )
             .animation(.easeInOut(duration: 0.1), value: store.state.focusedPlaceIndex)
             .padding(.bottom, 35.adjustedHeight)
             .padding(.horizontal, 20.adjustedWidth)
@@ -285,9 +281,11 @@ extension CourseDetailView {
                 },
                 onEntered: {
                     store.dispatch(.draggedInDeleteZone)
+                    HapticManager.shared.impact(style: .medium)
                 },
                 onExited: {
                     store.dispatch(.draggedOutDeleteZone)
+                    HapticManager.shared.impact(style: .medium)
                 }
             )
     }


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- iOS 26에서 드래그 앤 드롭이 막혔던 버그 수정했어요!
- 이거 수정함에 따라 스크롤 막혀있던 것도 정상 작동합니다
- 그리고 자잘한 버그들도 수정했어요 (코스에 장소 2개 남았을 때 장소 삭제 실패처리 & 햅틱 중복 버그 등등..)

|    구현 내용    |   iPhone 17 Pro (iOS26)   |
| :-------------: | :----------: |
| 실기기에서도 해봤어요 | <img src = "https://github.com/user-attachments/assets/1c338c0b-9952-4353-a1fa-ede87af786bf" width ="250"> |


## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 문제 상황

```Swift
              ScrollView
                  │
        ┌─────────┴─────────┐
        ↓                   ↓
   PanGesture           DragGesture
    (스크롤)          (손 떼는 시점 감지)
        │                   │
        └─────────┬─────────┘
                  ↓
           Gesture Conflict
                  ↓
       스크롤 / Drag & Drop 오류
```

`ScrollView` 내부에서 드래그 앤 드롭을 구현하기 위해 `.simultaneousGesture`로 `DragGesture`를 추가했는데,
두 가지 문제가 발생하였습니다...

`ScrollView`의 기본 `PanGesture`와 `simultaneousGesture`로 등록한 `DragGesture`가 서로 겹치면서
스크롤 자체가 동작하지 않음 ,제스처 우선순위 문제로 드래그 앤 드롭도 제대로 동작하지 않음

👉🏻 **결과적으로 "사용자가 꾹 눌렀다가 움직이지 않고 손을 뗀 시점" 을 감지할 방법이 없어짐.**

**왜 이 시점을 감지해야 하는가**
눌림과 동시에: `Row`가 반투명해지고 `deleteZone`이 나타나야 함
놓음과 동시에: `Row`가 원래 상태로 돌아오고 `deleteZone`이 사라져야 함

그런데 꾹 누른 상태에서 순서를 바꾸고 손을 떼는 경우엔 `.onDrop`이 호출되어 2번 동작이 정상적으로 처리되지만, 아무 움직임 없이 누르고만 있다가 손을 떼는 경우엔 `.onDrop`이 호출되지 않아 `Row`와 `deleteZone`이 **화면에 그대로 남는 문제가 있었습니다.**

### 해결 방법

이 문제를 해결하기 위해 `UIViewRepresentable`을 다시 도입.
`DragDropModifier`에 투명한 뷰를 오버레이하고, **해당 뷰에서 UIKit 제스처를 활용해 손을 떼는 시점을 처리하도록 하였슴니다.**

🤔 **왜 단순히 longPressGesture를 쓰지 않았는가???**

처음엔 "그냥 오버레이하고 롱프레스만 감지하면 되지 않나?" 싶었지만,
실제로 필요한 건 **단순 롱프레스가 아니라 "드래그 없이 꾹 눌렀다 떼는" 제스처였습니다.**

- SwiftUI의 longPressGesture는 드래그 여부와 무관하게 호출되기 때문에 조건을 구분할 수 없음
- 또한 SwiftUI의 롱프레스 제스처만으로는 우리가 원하는 "손을 뗀 시점"을 정확히 구분할 수 없음

😀 **UIViewRepresentable을 사용한 이유**
- `delegate`를 통해 드래그와 스크롤을 동시에 인식 가능
- `allowableMovement`로 드래그와 단순 롱프레스를 정확히 구분 가능
- 제스처의 상태(began/changed/ended 등)를 직접 관리 가능

`UILongPressGestureRecognizer`를 SwiftUI에 연결하여 "꾹 누르고 → 움직이지 않고 → 손을 뗀 시점"을 감지하는 UIViewRepresentable을 새로 작성했어요.

`minimumPressDuration`: 롱프레스로 인식되는 최소 시간
`allowableMovement`: 허용되는 최대 이동 거리 (초과 시 롱프레스 취소 처리)
`onLongPress`: 조건을 모두 만족했을 때(꾹 누르고, 허용 범위 내에서, 손을 뗀 경우) 호출되는 콜백

gestureRecognizer(_:shouldRecognizeSimultaneouslyWith:)를 통해 다른 제스처(onDrag 등)와의 동시 인식을 허용하여 SwiftUI 제스처와의 충돌 방지!!

<details>
<summary>코드 with 주석</summary>

```Swift
//
//  LongPressRecognizerView.swift
//  Solply
//
//  Created by 김승원 on 12/12/25.
//

import SwiftUI

/// UILongPressGestureRecognizer를 SwiftUI에 연결하여
/// "꾹 누르고 → 움직이지 않고 → 손을 뗀 시점" 을 감지하는 UIViewRepresentable.
/// - SwiftUI의 기본 onLongPressGesture는 '손 떼는 시점'을 지원하지 않기 때문에 필요한 커스텀 뷰.
struct LongPressRecognizerView: UIViewRepresentable {
    
    // MARK: - Properties

    /// 길게 눌러야 인식되는 최소 시간
    let minimumPressDuration: TimeInterval
    
    /// 롱프레스 중 허용되는 최대 이동 거리 (이 값을 넘으면 롱프레스 취소 처리)
    let allowableMovement: CGFloat
    
    /// "꾹 누르고 움직이지 않고 손을 뗀 순간"에 호출되는 콜백
    let onLongPress: (() -> Void)?
    
    // MARK: - Initializer
    
    init(
        minimumPressDuration: TimeInterval,
        allowableMovement: CGFloat,
        onLongPress: (() -> Void)? = nil
    ) {
        self.minimumPressDuration = minimumPressDuration
        self.allowableMovement = allowableMovement
        self.onLongPress = onLongPress
    }
    
    // MARK: - UIViewRepresentable

    func makeUIView(context: Context) -> UIView {
        let view = UIView(frame: .zero)
        view.isUserInteractionEnabled = true

        // UILongPressGestureRecognizer 설정
        let longPressGesture = UILongPressGestureRecognizer(
            target: context.coordinator,
            action: #selector(Coordinator.handleLongPress)
        )
        
        longPressGesture.minimumPressDuration = minimumPressDuration
        longPressGesture.cancelsTouchesInView = false
        longPressGesture.delaysTouchesBegan = false
        longPressGesture.delaysTouchesEnded = false
        longPressGesture.delegate = context.coordinator

        view.addGestureRecognizer(longPressGesture)

        // Coordinator가 gesture와 host view를 참조하도록 설정
        context.coordinator.gesture = longPressGesture
        context.coordinator.hostView = view

        return view
    }

    func updateUIView(_ uiView: UIView, context: Context) { }

    func makeCoordinator() -> Coordinator {
        Coordinator(self)
    }
}

// MARK: - Coordinator

extension LongPressRecognizerView {
    /// UILongPressGestureRecognizer의 상태 변화를 관리하고,
    /// 움직임 거리와 종료 시점을 판단하여 onLongPress를 호출하는 coordinator.
    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
        
        // MARK: - Properties

        /// 롱프레스가 시작된 위치
        private var beganLocation: CGPoint?

        /// 지정된 allowableMovement 범위를 넘었는지 여부
        private var movedTooFar = false

        /// LongPressGestureRecognizer
        weak var gesture: UILongPressGestureRecognizer?

        /// 제스처가 추가된 UIView
        weak var hostView: UIView?
        
        /// 부모 UIViewRepresentable
        var parent: LongPressRecognizerView
        
        // MARK: - Initializer

        init(_ parent: LongPressRecognizerView) {
            self.parent = parent
        }
        
        // MARK: - Gesture Handling

        /// UILongPressGestureRecognizer의 상태 변화 처리
        @objc
        func handleLongPress(_ longPressGesture: UILongPressGestureRecognizer) {
            guard let host = hostView else { return }
            let location = longPressGesture.location(in: host)

            switch longPressGesture.state {

            case .began:
                // 롱프레스 시작 → 시작 위치 저장
                beganLocation = location
                movedTooFar = false
                
            case .changed:
                // 손가락 이동 거리 계산 → 허용 범위를 벗어나면 롱프레스 실패 처리
                if let start = beganLocation {
                    let dx = location.x - start.x
                    let dy = location.y - start.y
                    let distance = sqrt(dx*dx + dy*dy)
                    
                    // allowableMovement를 벗어나면 롱프레스 취소 플래그 설정
                    if distance > parent.allowableMovement {
                        movedTooFar = true
                    }
                }
                
            case .ended:
                // 꾹 눌렀고, allowableMovement 안에서, 손을 뗀 경우만 성공으로 처리
                if movedTooFar == false {
                    parent.onLongPress?()
                }
                
                // 상태 초기화
                beganLocation = nil
                movedTooFar = false
                
            case .cancelled, .failed:
                // 제스처가 취소·실패되면 상태 초기화
                beganLocation = nil
                movedTooFar = false
                
            default:
                break
            }
        }

        // MARK: - Gesture Delegate

        /// 다른 제스처(onDrag 등)와 동시 인식을 허용하여 SwiftUI 제스처와 충돌 방지
        func gestureRecognizer(
            _ gestureRecognizer: UIGestureRecognizer,
            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
        ) -> Bool {
            return true
        }
    }
}

```

</details>

[Simultaneous DragGesture inside Scrollview broken in iOS 26?](https://stackoverflow.com/questions/79766009/simultaneous-draggesture-inside-scrollview-broken-in-ios-26?utm_source=chatgpt.com) 
스택오버플로 참고

### 햅틱매니저 추가
```Swift
import SwiftUI

final class HapticManager {
    
    static let shared = HapticManager()
    private init() {}
    
    /// 지정한 타입의 알림 햅틱을 발생시킵니다.
    /// - Parameter type: `.success`, `.warning`, `.error`
    func notification(type: UINotificationFeedbackGenerator.FeedbackType) {
        let generator = UINotificationFeedbackGenerator()
        generator.notificationOccurred(type)
    }
    
    /// 지정한 타입의 임팩트 햅틱을 발생시킵니다.
    /// - Parameter style: `.light`, `.medium`, `.heavy`, `.soft`, `.rigid`
    func impact(style: UIImpactFeedbackGenerator.FeedbackStyle) {
        let generator = UIImpactFeedbackGenerator(style: style)
        generator.impactOccurred()
    }
}
```
저희 서비스 코스 수정에서 장소를 꾹 누르거나, `deleteZone`에 들어갔다 나왔다 할 때 햅틱 기능이 있는데요, 너무 코드가 중복되기도 하고, 나중을 위해 햅틱을 골라 쓸 수 있게 해놨습니다.
```Swift
HapticManager.shared.impact(style: .medium)
HapticManager.shared.notification(type: .error)
```
요런 식으로 사용하면 됨!


## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #356 

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
https://stackoverflow.com/questions/79766009/simultaneous-draggesture-inside-scrollview-broken-in-ios-26

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 아 나 다음 주 시험인데, 이게 더 재밌다!
