### PR TITLE
[refactor/#368] MainTag, SubTag String으로 받도록 변경

### DIFF
--- a/Solply/Solply/Global/Enum/MainTagType.swift
+++ b/Solply/Solply/Global/Enum/MainTagType.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 
 enum MainTagType: String, CaseIterable, Identifiable, ResponseModelType, RequestModelType {
-    case all = "ALL"
-    case cafe = "CAFE"
-    case food = "FOOD"
-    case shopping = "SHOPPING"
-    case book = "BOOKSTORE"
-    case unique = "UNIQUE_SPACE"
-    case walk = "WALKING"
+    case all = "전체"
+    case cafe = "카페"
+    case food = "음식"
+    case shopping = "쇼핑"
+    case book = "서점/책방"
+    case unique = "이색공간"
+    case walk = "산책"
     
     var id: Self { self }
     

--- a/Solply/Solply/Global/Enum/SubTagType.swift
+++ b/Solply/Solply/Global/Enum/SubTagType.swift
@@ -10,40 +10,40 @@ import Foundation
 enum SubTagType: String, ResponseModelType, RequestModelType {
 
     // MARK: - 카페 추천 옵션 1
-    case coffeeDessert = "COFFEE_DESSERT"
-    case work = "WORK"
-    case reading = "READING"
-    case healing = "HEALING"
+    case coffeeDessert = "커피/디저트"
+    case work = "작업"
+    case reading = "독서"
+    case healing = "힐링"
 
     // MARK: - 카페 추천 옵션 2
-    case signatureMenu = "SIGNATURE_MENU"
-    case moodInterior = "MOOD_INTERIOR"
-    case sunlight = "SUNLIGHT"
-    case manyPlug = "MANY_PLUG"
-    case noTimeLimit = "NO_TIME_LIMIT"
-    case barTable = "BAR_TABLE"
+    case signatureMenu = "시그니처메뉴"
+    case moodInterior = "감성인테리어"
+    case sunlight = "채광좋음"
+    case manyPlug = "콘센트많음"
+    case noTimeLimit = "시간제한없음"
+    case barTable = "바테이블"
 
     // MARK: - 음식 추천 옵션 1
-    case koreanFood = "KOREAN_FOOD"
-    case chineseFood = "CHINESE_FOOD"
-    case japaneseFood = "JAPANESE_FOOD"
-    case westernFood = "WESTERN_FOOD"
-    case bar = "BAR"
-    case bakery = "BAKERY"
-    case asianFood = "ASIAN_FOOD"
+    case koreanFood = "한식"
+    case chineseFood = "중식"
+    case japaneseFood = "일식"
+    case westernFood = "양식"
+    case bar = "바/술집"
+    case bakery = "베이커리"
+    case asianFood = "아시안푸드"
 
     // MARK: - 음식 추천 옵션 2
-    case singleMenu = "SINGLE_MENU"
-    case selfService = "SELF_SERVICE"
+    case singleMenu = "1인메뉴"
+    case selfService = "셀프서비스"
 
     // MARK: - 이색공간 추천 옵션
-    case art = "ART"
-    case workshop = "WORKSHOP"
+    case art = "문화예술"
+    case workshop = "공방/클래스"
 
     // MARK: - 쇼핑 추천 옵션
-    case lifestyleShop = "LIFESTYLE_SHOP"
-    case vintageShop = "VINTAGE_SHOP"
-    case popupMarket = "POPUP_MARKET"
+    case lifestyleShop = "소품샵"
+    case vintageShop = "빈티지샵"
+    case popupMarket = "팝업/플리마켓"
     
     
     var title: String {

--- a/Solply/Solply/Network/DTO/Place/ResponseDTO/PlaceListResponseDTO.swift
+++ b/Solply/Solply/Network/DTO/Place/ResponseDTO/PlaceListResponseDTO.swift
@@ -15,6 +15,6 @@ struct PlaceDTO: ResponseModelType {
     let placeId: Int
     let placeName: String
     let thumbnailImageUrl: String
-    let primaryTag: MainTagType
+    let primaryTag: String
     let isBookmarked: Bool
 }

--- a/Solply/Solply/Network/DTO/Place/ResponseDTO/PlaceRecommendResponseDTO.swift
+++ b/Solply/Solply/Network/DTO/Place/ResponseDTO/PlaceRecommendResponseDTO.swift
@@ -15,6 +15,6 @@ struct PlaceInfoDTO: ResponseModelType {
     let placeId: Int
     let placeName: String
     let thumbnailImageUrl: String
-    let mainTag: MainTagType
+    let mainTag: String
     let introduction: String
 }

--- a/Solply/Solply/Network/DTO/Tags/ResponseDTO/MainTagsResponseDTO.swift
+++ b/Solply/Solply/Network/DTO/Tags/ResponseDTO/MainTagsResponseDTO.swift
@@ -14,6 +14,6 @@ struct MainTagsResponseDTO: ResponseModelType {
 struct MainTagDTO: ResponseModelType {
     let tagId: Int
     let tagType: String
-    let name: MainTagType
+    let name: String
     let parentId: Int?
 }

--- a/Solply/Solply/Network/DTO/Tags/ResponseDTO/SubTagsResponseDTO.swift
+++ b/Solply/Solply/Network/DTO/Tags/ResponseDTO/SubTagsResponseDTO.swift
@@ -14,6 +14,6 @@ struct SubTagsResponseDTO: ResponseModelType {
 struct SubTagDTO: ResponseModelType {
     let tagId: Int
     let tagType: String
-    let name: SubTagType
+    let name: String
     let parentId: Int?
 }

--- a/Solply/Solply/Presentation/Archive/Component/ArchiveListFullView.swift
+++ b/Solply/Solply/Presentation/Archive/Component/ArchiveListFullView.swift
@@ -60,7 +60,7 @@ extension ArchiveListFullView {
                 isSaved: true,
                 thumbnailUrl: item.thumbnailImageUrl,
                 placeName: item.placeName,
-                placeCategory: item.primaryTag,
+                placeCategory: MainTagType(rawValue: item.primaryTag) ?? .book,
                 isSelected: store.state.selectedPlaceIds.contains(item.placeId),
             ) {
                 if store.state.activeDelete {

--- a/Solply/Solply/Presentation/Place/Component/TodayPlaceRecommendCarousel.swift
+++ b/Solply/Solply/Presentation/Place/Component/TodayPlaceRecommendCarousel.swift
@@ -65,9 +65,14 @@ struct TodayPlaceRecommendCarousel: View {
                     .scaleEffect(scale)
                     .offset(x: totalOffset)
                 }
+            } else {
+                Text("추천 장소가 없어요")
+                    .applySolplyFont(.body_14_m)
+                    .foregroundStyle(.gray700)
+                    .frame(maxWidth: .infinity, alignment: .center)
             }
         }
-        .frame(height: 240.adjusted)
+        .frame(height: store.state.placeRecommendItems.isEmpty ? 60.adjustedHeight : 240.adjusted)
         .gesture(
             DragGesture()
                 .onChanged { value in

--- a/Solply/Solply/Presentation/Place/PlaceRecommend/Entity/MainTag.swift
+++ b/Solply/Solply/Presentation/Place/PlaceRecommend/Entity/MainTag.swift
@@ -17,6 +17,6 @@ extension MainTag {
     init(dto: MainTagDTO) {
         self.id = dto.tagId
         self.tagType = dto.tagType
-        self.name = dto.name
+        self.name = MainTagType(rawValue:dto.name) ?? .book
     }
 }

--- a/Solply/Solply/Presentation/Place/PlaceRecommend/Entity/Place.swift
+++ b/Solply/Solply/Presentation/Place/PlaceRecommend/Entity/Place.swift
@@ -22,7 +22,7 @@ extension Place {
         self.placeId = dto.placeId
         self.placeName = dto.placeName
         self.thumbnailUrl = dto.thumbnailImageUrl
-        self.mainTag = dto.primaryTag
+        self.mainTag = MainTagType(rawValue: dto.primaryTag) ?? .book
         self.isBookmarked = dto.isBookmarked
     }
 }

--- a/Solply/Solply/Presentation/Place/PlaceRecommend/Entity/PlaceRecommend.swift
+++ b/Solply/Solply/Presentation/Place/PlaceRecommend/Entity/PlaceRecommend.swift
@@ -19,7 +19,7 @@ extension PlaceRecommend {
     init(dto: PlaceInfoDTO) {
         self.id = dto.placeId
         self.thumbnailUrl = dto.thumbnailImageUrl
-        self.category = dto.mainTag
+        self.category = MainTagType(rawValue: dto.mainTag) ?? .book
         self.title = dto.placeName
         self.introduction = dto.introduction
     }

--- a/Solply/Solply/Presentation/Place/PlaceRecommend/Entity/SubTag.swift
+++ b/Solply/Solply/Presentation/Place/PlaceRecommend/Entity/SubTag.swift
@@ -17,6 +17,6 @@ extension SubTag {
     init(dto: SubTagDTO) {
         self.id = dto.tagId
         self.tagType = dto.tagType
-        self.name = dto.name
+        self.name = SubTagType(rawValue: dto.name) ?? .art
     }
 }

--- a/Solply/Solply/Presentation/Place/PlaceRecommend/View/PlaceRecommendView.swift
+++ b/Solply/Solply/Presentation/Place/PlaceRecommend/View/PlaceRecommendView.swift
@@ -37,9 +37,7 @@ struct PlaceRecommendView: View {
                 }
                 .padding(.horizontal, 20.adjustedWidth)
                 
-                if !store.state.placeRecommendItems.isEmpty {
-                    TodayPlaceRecommendCarousel(store: store, townId: appState.townId)
-                }
+                TodayPlaceRecommendCarousel(store: store, townId: appState.townId)
                 
                 FilterPlaceGrid(store: store, townId: appState.townId)
                     .padding(.horizontal, 16.adjustedWidth)


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- DTO에 MainTagType, SubTagType을 String(한글)으로 받도록 수정했어요
- 일단 기획측에서 태그가 수정되거나 추가되는 일이 많이 일어나지는 않을 거라고 하셔서, 임시 방편(?) 느낌으로 수정했습니다.
- 나중에 이 태그 관리 관련해서 논의가 필요할 거 같네요!

|    태그    |   iPhone 17 Pro   |
| :-------------: | :----------: |
| A 기능 | <img src = "https://github.com/user-attachments/assets/7d50780d-aefa-454b-93d9-cc60ed705b66" width ="250"> |


## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 뭘 고쳐놨냐면
```Swift
// PlaceRecommendResponseDTO.swift

struct PlaceRecommendResponseDTO: ResponseModelType {
    let placeInfos: [PlaceInfoDTO]
}

struct PlaceInfoDTO: ResponseModelType {
    let placeId: Int
    let placeName: String
    let thumbnailImageUrl: String
    let mainTag: String // <- 원래 MainTagType으로 받던 걸 String으로 변경
    let introduction: String
}
```
위 처럼 String으로 받게 수정하여 디코딩 에러를 해결했습니다. 그리고 이를 사용해서 엔티티로 변환하는 과정에서
`MainTagType(rawValue: ...) ?? .book`이렇게 rawValue를 활용하여 초기화하는 방법으로 수정했어요

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

일단 임시로 `.book`을 default값으로 해놨는데, 출시 이후 한번 개편이 필요해 보입니다.
지금으로는 클라에서 태그마다 아이콘이나 색상을 다 `Enum`으로 관리하고 있어서 서버에서 태그가 업데이트 됐을 경우 바로 대응이 되지 않는 구조라 `.book`으로 기본값으로 해놨어요.
(그러니까 예를 들어 태그 중에 "운동"이라는 게 생기면 우리가 그걸 받았을 때 바로 대응이 되지 않기 때문에 없는 태그String값이 들어오면 .book으로 표시하게끔 해놨다는 것. 하지만 태그가 추가&수정될 일은 거의 일어나지 않을 거라고 기획쌤들이 그랬기 때문에 일단은 이렇게 가는 게 좋을 거 같습니다)

아 그리고 현재 장소 서버쌤들이 장소 추천 로직을 수정(?) 중에 있어서 지금은 장소 추천 리스트가 빈 배열로 내려와요. 그래서 일단 없을 때 뷰를 추가해 놨습니닷 

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #368 
