### PR TITLE
[fix/#382] 사진 라이브러리 접근 권한 요청 문구 수정

### DIFF
--- a/Solply/Solply.xcodeproj/project.pbxproj
+++ b/Solply/Solply.xcodeproj/project.pbxproj
@@ -312,7 +312,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "앱이 위치 정보를 사용하여 위경도를 표시합니다.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "앱이 위치 정보를 기반으로 현재 위치, 주변 검색, 길찾기 정보를 제공합니다.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "앱에서 사진을 보려면 솔플리가 사진 라이브러리에 액세스 할 수 있어야 합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "프로필 사진 설정과 콘텐츠에 이미지를 첨부할 수 있도록 사진 라이브러리에 접근합니다.\n선택한 사진은 프로필 이미지 또는 사용자가 첨부한 콘텐츠에만 사용됩니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -355,7 +355,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "앱이 위치 정보를 사용하여 위경도를 표시합니다.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "앱이 위치 정보를 기반으로 현재 위치, 주변 검색, 길찾기 정보를 제공합니다.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "앱에서 사진을 보려면 솔플리가 사진 라이브러리에 액세스 할 수 있어야 합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "프로필 사진 설정과 콘텐츠에 이미지를 첨부할 수 있도록 사진 라이브러리에 접근합니다.\n선택한 사진은 프로필 이미지 또는 사용자가 첨부한 콘텐츠에만 사용됩니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Solply/Solply/Global/Info.plist
+++ b/Solply/Solply/Global/Info.plist
@@ -4,12 +4,6 @@
 <dict>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
-	<key>PRIVACY_POLICY_URL</key>
-	<string>$(PRIVACY_POLICY_URL)</string>
-	<key>SERVICE_POLICY_URL</key>
-	<string>$(SERVICE_POLICY_URL)</string>
-	<key>CUSTOMER_CENTER_URL</key>
-	<string>$(CUSTOMER_CENTER_URL)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -21,6 +15,8 @@
 			</array>
 		</dict>
 	</array>
+	<key>CUSTOMER_CENTER_URL</key>
+	<string>$(CUSTOMER_CENTER_URL)</string>
 	<key>KAKAO_NATIVE_APP_KEY</key>
 	<string>$(KAKAO_NATIVE_APP_KEY)</string>
 	<key>LSApplicationQueriesSchemes</key>
@@ -41,6 +37,10 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>PRIVACY_POLICY_URL</key>
+	<string>$(PRIVACY_POLICY_URL)</string>
+	<key>SERVICE_POLICY_URL</key>
+	<string>$(SERVICE_POLICY_URL)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-SemiBold.otf</string>


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 까다로운 애플자식들

|    구현 내용    |   iPhone 17 pro   |
| :-------------: | :----------: |
| 권한 문구 | <img src = "https://github.com/user-attachments/assets/75b78ee5-f8c7-4f59-b54a-c82bd2686be5" width ="250"> |

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #382 