### PR TITLE
[chore/#477] 앱 네이밍 분리

### DIFF
--- a/Solply/Solply.xcodeproj/project.pbxproj
+++ b/Solply/Solply.xcodeproj/project.pbxproj
@@ -351,7 +351,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Solply/Global/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "솔플리dev";
+				INFOPLIST_KEY_CFBundleDisplayName = "솔플리";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "앱이 위치 정보를 사용하여 위경도를 표시합니다.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "앱이 위치 정보를 기반으로 현재 위치, 주변 검색, 길찾기 정보를 제공합니다.";


### PR DESCRIPTION
## 📄 작업 내용
- 앱 네이밍 요상한 거 수정

|    구현 내용    |   iPhone 13 mini   |  
| :-------------: | :----------: |
| 데브랑 릴리즈로 앱 네이밍이 수정됩니듀 | <img src = "https://github.com/user-attachments/assets/7d80663c-920a-4b45-8971-40476adf7e48" width ="250"> | 
