### PR TITLE
[feat/#488] 장소 상세 리뷰 연동

### DIFF
--- a/Solply/Solply/Global/Enum/VisitTime.swift
+++ b/Solply/Solply/Global/Enum/VisitTime.swift
@@ -1,0 +1,24 @@
+//
+//  VisitTime.swift
+//  Solply
+//
+//  Created by 김승원 on 4/11/26.
+//
+
+import Foundation
+
+enum VisitTime: String, CaseIterable, ResponseModelType, RequestModelType {
+    case morning = "MORNING"
+    case afternoon = "AFTERNOON"
+    case evening = "EVENING"
+}
+
+extension VisitTime {
+    var title: String {
+        switch self {
+        case .morning: return "오전"
+        case .afternoon: return "오후"
+        case .evening: return "저녁"
+        }
+    }
+}

--- a/Solply/Solply/Global/Enum/VisitTime.swift
+++ b/Solply/Solply/Global/Enum/VisitTime.swift
@@ -2,7 +2,7 @@
 //  VisitTime.swift
 //  Solply
 //
-//  Created by 김승원 on 4/11/26.
+//  Created by sun on 4/11/26.
 //
 
 import Foundation

--- a/Solply/Solply/Global/Modifier/CustomLoadingModifier.swift
+++ b/Solply/Solply/Global/Modifier/CustomLoadingModifier.swift
@@ -27,13 +27,14 @@ struct CustomLoadingModifier<T>: ViewModifier where T: View {
     // MARK: - Body
     
     func body(content: Content) -> some View {
-        Group {
-            if isLoading {
-                self.loadingView?()
-            } else {
-                content
+        content
+            .opacity(isLoading ? 0 : 1)
+            .overlay(alignment: .top) {
+                if isLoading {
+                    self.loadingView?()
+                        .allowsHitTesting(false)
+                }
             }
-        }
     }
 }
 

--- a/Solply/Solply/Network/DTO/Place/ResponseDTO/PlaceDetailResponseDTO.swift
+++ b/Solply/Solply/Network/DTO/Place/ResponseDTO/PlaceDetailResponseDTO.swift
@@ -41,8 +41,9 @@ struct ReviewDTO: ResponseModelType {
     let reviewId: Int
     let userId: Int
     let nickname: String
-    let profileImageUrl: String
+    let profileImageUrl: String?
     let content: String
     let visitedAt: String
+    let visitTimeSlot: VisitTime
     let imageUrls: [String]
 }

--- a/Solply/Solply/Network/DTO/Place/ResponseDTO/PlaceDetailResponseDTO.swift
+++ b/Solply/Solply/Network/DTO/Place/ResponseDTO/PlaceDetailResponseDTO.swift
@@ -11,6 +11,7 @@ struct PlaceDetailResponseDTO: ResponseModelType {
     let placeId: Int
     let placeName: String
     let mainTag: MainTagType
+    let optionTags: [SubTagType]
     let introduction: String
     let imageInfos: [ImageInfoDTO]
     let address: String
@@ -23,6 +24,7 @@ struct PlaceDetailResponseDTO: ResponseModelType {
     let isBookmarked: Bool
     let townId: Int
     let townName: String
+    let latestReviews: [ReviewDTO]
 }
 
 struct ImageInfoDTO: ResponseModelType {
@@ -33,4 +35,14 @@ struct ImageInfoDTO: ResponseModelType {
 struct SnsLinkDTO: ResponseModelType {
     let snsPlatform: String
     let url: String
+}
+
+struct ReviewDTO: ResponseModelType {
+    let reviewId: Int
+    let userId: Int
+    let nickname: String
+    let profileImageUrl: String
+    let content: String
+    let visitedAt: String
+    let imageUrls: [String]
 }

--- a/Solply/Solply/Presentation/Place/Component/PlaceMarkerMap.swift
+++ b/Solply/Solply/Presentation/Place/Component/PlaceMarkerMap.swift
@@ -12,32 +12,28 @@ struct PlaceMarkerMap: View {
     
     // MARK: - Properties
     
-    private let latitude: Double
-    private let longitude: Double
-    private let region: MKCoordinateRegion
+    private let latitude: Double?
+    private let longitude: Double?
     
     // MARK: - Initializer
     
-    init(latitude: Double, longitude: Double) {
+    init(latitude: Double?, longitude: Double?) {
         self.latitude = latitude
         self.longitude = longitude
-        
-        let coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
-        let region = MKCoordinateRegion(
-            center: coordinate,
-            span: MKCoordinateSpan(latitudeDelta: 0.015, longitudeDelta: 0.015)
-        )
-        self.region = region
     }
     
     // MARK: - Body
     
     var body: some View {
-        if latitude == 0.0 || longitude == 0.0 {
-            Color.clear
-        } else {
+        if let latitude, let longitude {
+            let coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+            let region = MKCoordinateRegion(
+                center: coordinate,
+                span: MKCoordinateSpan(latitudeDelta: 0.015, longitudeDelta: 0.015)
+            )
+            
             Map(initialPosition: .region(region), interactionModes: []) {
-                Annotation("", coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude), anchor: .bottom) {
+                Annotation("", coordinate: coordinate, anchor: .bottom) {
                     Image(.mapMarkPlace)
                         .resizable()
                         .aspectRatio(contentMode: .fit)

--- a/Solply/Solply/Presentation/Place/Component/PlaceMarkerMap.swift
+++ b/Solply/Solply/Presentation/Place/Component/PlaceMarkerMap.swift
@@ -33,15 +33,19 @@ struct PlaceMarkerMap: View {
     // MARK: - Body
     
     var body: some View {
-        Map(initialPosition: .region(region), interactionModes: []) {
-            Annotation("", coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude), anchor: .bottom) {
-                Image(.mapMarkPlace)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 36.adjusted, height: 36.adjusted)
+        if latitude == 0.0 || longitude == 0.0 {
+            Color.clear
+        } else {
+            Map(initialPosition: .region(region), interactionModes: []) {
+                Annotation("", coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude), anchor: .bottom) {
+                    Image(.mapMarkPlace)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 36.adjusted, height: 36.adjusted)
+                }
             }
+            .mapControlVisibility(.hidden)
+            .mapStyle(.standard)
         }
-        .mapControlVisibility(.hidden)
-        .mapStyle(.standard)
     }
 }

--- a/Solply/Solply/Presentation/Place/PlaceDetail/Effect/PlaceDetailEffect.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/Effect/PlaceDetailEffect.swift
@@ -93,8 +93,9 @@ extension PlaceDetailEffect {
             }
             
             let placeDetailInformation = PlaceDetailInformation(dto: data)
+            let records = data.latestReviews.map { Record($0) }
             
-            return .placeDetailFetched(placeDetailInformation: placeDetailInformation)
+            return .placeDetailFetched(placeDetailInformation: placeDetailInformation, records: records)
         } catch let error as NetworkError {
             return .fetchPlaceDetailFailed(error: error)
         } catch {

--- a/Solply/Solply/Presentation/Place/PlaceDetail/Entity/PlaceDetailInformation.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/Entity/PlaceDetailInformation.swift
@@ -21,6 +21,7 @@ struct PlaceDetailInformation {
     let longitude: Double
     let townId: Int
     let townName: String
+    let solplyTips: [SubTagType]
     let placeCheckpoints: [String]
 }
 
@@ -39,6 +40,7 @@ extension PlaceDetailInformation {
         self.longitude = Double(dto.longitude) ?? 0.0
         self.townId = dto.townId
         self.townName = dto.townName
+        self.solplyTips = dto.optionTags
         self.placeCheckpoints = dto.placeCheckpoints
     }
     

--- a/Solply/Solply/Presentation/Place/PlaceDetail/Entity/Record.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/Entity/Record.swift
@@ -25,7 +25,7 @@ extension Record {
         self.userName = reviewDto.nickname
         self.photoUrls = reviewDto.imageUrls
         self.recordText = reviewDto.content
-        self.visitTime = reviewDto.visitedAt
+        self.visitTime = "\(reviewDto.visitedAt.replacingOccurrences(of: "-", with: ".")) \(reviewDto.visitTimeSlot.title) 방문"
     }
 }
 

--- a/Solply/Solply/Presentation/Place/PlaceDetail/Entity/Record.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/Entity/Record.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 struct Record: Identifiable {
-    let id = UUID()
+    let id: Int
+    let userId: Int
     let profileImageUrl: String?
     let userName: String
     let photoUrls: [String]
@@ -17,9 +18,23 @@ struct Record: Identifiable {
 }
 
 extension Record {
+    init(_ reviewDto: ReviewDTO) {
+        self.id = reviewDto.reviewId
+        self.userId = reviewDto.userId
+        self.profileImageUrl = reviewDto.profileImageUrl
+        self.userName = reviewDto.nickname
+        self.photoUrls = reviewDto.imageUrls
+        self.recordText = reviewDto.content
+        self.visitTime = reviewDto.visitedAt
+    }
+}
+
+extension Record {
     static var mock: [Record] {
         return [
             Record(
+                id: 1,
+                userId: 1,
                 profileImageUrl: "https://i.pinimg.com/1200x/23/ce/ea/23ceead7c9d0d5db016b404faa3bbd87.jpg",
                 userName: "민지",
                 photoUrls: [
@@ -33,6 +48,8 @@ extension Record {
                 visitTime: "2026.02.19 오후 방문"
             ),
             Record(
+                id: 2,
+                userId: 2,
                 profileImageUrl: nil,
                 userName: "승원",
                 photoUrls: [
@@ -43,6 +60,8 @@ extension Record {
                 visitTime: "2026.02.19 오후 방문"
             ),
             Record(
+                id: 3,
+                userId: 3,
                 profileImageUrl: "https://i.pinimg.com/1200x/23/ce/ea/23ceead7c9d0d5db016b404faa3bbd87.jpg",
                 userName: "솔플릴",
                 photoUrls: [],
@@ -50,6 +69,8 @@ extension Record {
                 visitTime: "2026.02.19 오후 방문"
             ),
             Record(
+                id: 4,
+                userId: 4,
                 profileImageUrl: "https://i.pinimg.com/1200x/23/ce/ea/23ceead7c9d0d5db016b404faa3bbd87.jpg",
                 userName: "민지",
                 photoUrls: [
@@ -62,6 +83,8 @@ extension Record {
                 visitTime: "2026.02.19 오후 방문"
             ),
             Record(
+                id: 5,
+                userId: 5,
                 profileImageUrl: "https://i.pinimg.com/1200x/23/ce/ea/23ceead7c9d0d5db016b404faa3bbd87.jpg",
                 userName: "민지",
                 photoUrls: [

--- a/Solply/Solply/Presentation/Place/PlaceDetail/Intent/PlaceDetailAction.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/Intent/PlaceDetailAction.swift
@@ -38,7 +38,7 @@ enum PlaceDetailAction {
     case fetchCourseArchiveFailed(error: NetworkError)
     
     case fetchPlaceDetail
-    case placeDetailFetched(placeDetailInformation: PlaceDetailInformation)
+    case placeDetailFetched(placeDetailInformation: PlaceDetailInformation, records: [Record])
     case fetchPlaceDetailFailed(error: NetworkError)
     
     case submitPlaceBookmark

--- a/Solply/Solply/Presentation/Place/PlaceDetail/Intent/PlaceDetailStore.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/Intent/PlaceDetailStore.swift
@@ -91,7 +91,7 @@ final class PlaceDetailStore: ObservableObject {
                 self.dispatch(result)
             }
             
-        case .placeDetailFetched(let placeDetailInformation):
+        case .placeDetailFetched(let placeDetailInformation, _):
             AmplitudeManager.shared.track(
                 .viewPlaceDetail(
                     placeId: placeId,

--- a/Solply/Solply/Presentation/Place/PlaceDetail/Intent/PlaceDetailStore.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/Intent/PlaceDetailStore.swift
@@ -49,32 +49,38 @@ final class PlaceDetailStore: ObservableObject {
             }
             
         case .findDirection(let mapRouteType):
+            
+            guard let userLatitude = state.userLatitude,
+                  let userLongitude = state.userLongitude,
+                  let latitude = state.latitude,
+                  let longitude = state.longitude else { return }
+            
             switch mapRouteType {
             case .naver:
                 effect.findDirection(
                     with: .naver,
-                    startLatitude: state.userLatitude,
-                    startLongitude: state.userLongitude,
-                    destinationLatitude: state.latitude,
-                    destinationLongitude: state.longitude,
+                    startLatitude: userLatitude,
+                    startLongitude: userLongitude,
+                    destinationLatitude: latitude,
+                    destinationLongitude: longitude,
                     destinationName: state.placeName
                 )
             case .apple:
                 effect.findDirection(
                     with: .apple,
-                    startLatitude: state.userLatitude,
-                    startLongitude: state.userLongitude,
-                    destinationLatitude: state.latitude,
-                    destinationLongitude: state.longitude,
+                    startLatitude: userLatitude,
+                    startLongitude: userLongitude,
+                    destinationLatitude: latitude,
+                    destinationLongitude: longitude,
                     destinationName: nil
                 )
             case .kakao:
                 effect.findDirection(
                     with: .kakao,
-                    startLatitude: state.userLatitude,
-                    startLongitude: state.userLongitude,
-                    destinationLatitude: state.latitude,
-                    destinationLongitude: state.longitude,
+                    startLatitude: userLatitude,
+                    startLongitude: userLongitude,
+                    destinationLatitude: latitude,
+                    destinationLongitude: longitude,
                     destinationName: nil
                 )
             }

--- a/Solply/Solply/Presentation/Place/PlaceDetail/State/PlaceDetailReducer.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/State/PlaceDetailReducer.swift
@@ -86,7 +86,7 @@ enum PlaceDetailReducer {
             state.isPlaceDetailLoading = true
             break
             
-        case .placeDetailFetched(let placeDetailInformation):
+        case .placeDetailFetched(let placeDetailInformation, let records):
             state.isPlaceDetailLoading = false
             state.isBookmarked = placeDetailInformation.isBookmarked
             state.primaryTag = placeDetailInformation.primaryTag
@@ -99,10 +99,9 @@ enum PlaceDetailReducer {
             state.snsLink = placeDetailInformation.snsLink
             state.latitude = placeDetailInformation.latitude
             state.longitude = placeDetailInformation.longitude
-            // TODO: - 솔플리 팁, 기록 서버 작업 후 수정 예정
-            state.solplyTips = [.reading, .work, .signatureMenu]
+            state.solplyTips = placeDetailInformation.solplyTips
             state.solplyCheckPoints = placeDetailInformation.placeCheckpoints
-            state.records = Record.mock
+            state.records = records
             
         case .submitPlaceBookmark:
             break

--- a/Solply/Solply/Presentation/Place/PlaceDetail/State/PlaceDetailState.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/State/PlaceDetailState.swift
@@ -15,8 +15,8 @@ struct PlaceDetailState {
     var isAddToCourseSheetPresented: Bool = false
     
     var bookmarkButtonSelected: Bool = false
-    var userLatitude: Double = 0.0
-    var userLongitude: Double = 0.0
+    var userLatitude: Double?
+    var userLongitude: Double?
     var addPlaceCourseInformation: AddPlaceCourseInformation?
     
     var courses: [AddToCourseArchive] = []
@@ -33,8 +33,8 @@ struct PlaceDetailState {
     var contactNumber: String = ""
     var openingHours: String = ""
     var snsLink: [PlaceDetailSnsLink] = []
-    var latitude: Double = 0.0
-    var longitude: Double = 0.0
+    var latitude: Double?
+    var longitude: Double?
     var solplyTips: [SubTagType] = []
     var solplyCheckPoints: [String] = []
     var records: [Record] = []

--- a/Solply/Solply/Presentation/Place/PlaceDetail/State/PlaceDetailState.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/State/PlaceDetailState.swift
@@ -39,6 +39,10 @@ struct PlaceDetailState {
     var solplyCheckPoints: [String] = []
     var records: [Record] = []
     
+    var moreRecordsButtonEnabled: Bool {
+        records.count > 3
+    }
+    
     var navigationBarTitle: String? = nil
     var imageViewerItem: ImageViewerItem? = nil
 }

--- a/Solply/Solply/Presentation/Place/PlaceDetail/View/PlaceDetailView.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/View/PlaceDetailView.swift
@@ -401,6 +401,7 @@ extension PlaceDetailView {
                 }
             } else {
                 emptyRecord
+                    .padding(.bottom, 32.adjustedHeight)
             }
         }
     }

--- a/Solply/Solply/Presentation/Place/PlaceDetail/View/PlaceDetailView.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/View/PlaceDetailView.swift
@@ -363,7 +363,7 @@ extension PlaceDetailView {
     
     private var record: some View {
         VStack(alignment: .center, spacing: 20.adjustedHeight) {
-            sectionHeader(title: "기록", moreButtonAction: store.state.records.count < 4 ? nil : {
+            sectionHeader(title: "기록", moreButtonAction: store.state.moreRecordsButtonEnabled ? nil : {
                 appCoordinator.navigate(to: .recordList)
             })
             .padding(.horizontal, 20.adjustedWidth)

--- a/Solply/Solply/Presentation/Record/RecordWrite/Intent/RecordWriteAction.swift
+++ b/Solply/Solply/Presentation/Record/RecordWrite/Intent/RecordWriteAction.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum RecordWriteAction {
     case selectDate(Date?)
-    case selectVisitTime(RecordWriteView.VisitTime)
+    case selectVisitTime(VisitTime)
     case writeRecordText(String)
     
     case selectTime([(fileName: String, data: Data)])

--- a/Solply/Solply/Presentation/Record/RecordWrite/State/RecordWriteState.swift
+++ b/Solply/Solply/Presentation/Record/RecordWrite/State/RecordWriteState.swift
@@ -11,7 +11,7 @@ struct RecordWriteState {
     var placeName: String
     
     var selectedDate: Date? = nil
-    var selectedVisitTime: RecordWriteView.VisitTime? = nil
+    var selectedVisitTime: VisitTime? = nil
     var recordText: String = ""
     var selectedPhotos: [(fileName: String, data: Data)] = []
     

--- a/Solply/Solply/Presentation/Record/RecordWrite/View/RecordWriteView.swift
+++ b/Solply/Solply/Presentation/Record/RecordWrite/View/RecordWriteView.swift
@@ -11,12 +11,6 @@ struct RecordWriteView: View {
     
     // MARK: - Properties
     
-    enum VisitTime: String, CaseIterable {
-        case morning = "오전"
-        case afternoon = "오후"
-        case evening = "저녁"
-    }
-    
     @EnvironmentObject private var appCoordinator: AppCoordinator
     @StateObject private var store: RecordWriteStore
     
@@ -124,7 +118,7 @@ extension RecordWriteView {
                 Button {
                     store.dispatch(.selectVisitTime(time))
                 } label: {
-                    Text(time.rawValue)
+                    Text(time.title)
                         .applySolplyFont(.body_16_r)
                         .foregroundStyle(
                             store.state.selectedVisitTime == time ? .coreWhite : .gray900


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 장소 상세 페이지에 솔플리 TIP, 리뷰 연동했습니다.
- 솔플리 TIP(태그) 는 아직 3개 초과일 때 UI가 안 나와서 다음 이슈에 반영하겠습니다.
- 영주누나가 만들었던 `VisitTime` `Global`로 뺐어요. 그리고 연관값 수정했습니다!

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| 리뷰 3개 노출 | <img src = "https://github.com/user-attachments/assets/955d8060-5b7c-4eaf-8542-7ca9b4d6cb26" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 로딩 방식 수정
```Swift
// CustomLoadingModifier.swift

// MARK: - Body
func body(content: Content) -> some View {
    content
        .opacity(isLoading ? 0 : 1)
        .overlay(alignment: .top) {
            if isLoading {
                self.loadingView?()
                    .allowsHitTesting(false)
            }
        }
}
```
기존에는 `if else`문으로 스켈레톤뷰랑 교체하도록 했는데, 이렇게 하니까 다른 뷰에 갔다가(**navigate**) 돌아오면 자꾸 스크롤 위치라던가.. 초기화 되더라고요. 그래서 스켈레톤뷰를 `.overlay`로 위에 올리는 방식으로 수정했습니다.

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #488 

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 지금 서버에서 시간을 "2026-00-00", "MORNING"이렇게 내려줘서 그냥 클라에서 처리하도록 햇어요
- 기록 리스트뷰는 아직 연동 안 했습니다! 다음 이슈에 할게요
- 로딩뷰를 overlay로 수정하니까 장소 상세 지도에 문제가 생겼었는데요, 초기 좌표가 (0, 0)이라서 기존에는 if else로 뷰를 갈아 끼워서 초기 좌표에서 진짜 좌표가 받아와지는 순간에 지도가 그려져서 잘 보였던 건데, overlay로 하니까 onAppear순간에도 지도가 사실상 띄워져 있는 거라서 초기값인 (0, 0)에 지도가 그려져서 바다 한 가운데만 보이더라고요. 그래서 실제 좌표 데이터를 받은 시점에 지도가 표시되도록 수정했어요.