### PR TITLE
[feat/#492] 기록하기 API 연동

### DIFF
--- a/Solply/Solply/Global/Component/RecordCard.swift
+++ b/Solply/Solply/Global/Component/RecordCard.swift
@@ -123,10 +123,11 @@ extension RecordCard {
     }
     
     private func photo(_ url: String) -> some View {
-        KFImage(URL(string: url))
-            .resizable()
-            .frame(width: 72.adjusted, height: 72.adjusted)
-            .aspectRatio(contentMode: .fill)
-            .cornerRadius(12, corners: .allCorners)
+        ThumbnailImage(
+            url,
+            width: 72.adjusted,
+            height: 72.adjusted,
+            radius: 12
+        )
     }
 }

--- a/Solply/Solply/Global/Coordinator/Destination/AppDestination.swift
+++ b/Solply/Solply/Global/Coordinator/Destination/AppDestination.swift
@@ -23,6 +23,7 @@ enum AppDestination: Hashable {
     case registerComplete
     case customerCenter
     case recordList(placeId: Int)
+    case recordWrite(placeId: Int, placeName: String)
     case aiRecommend
 }
 
@@ -60,6 +61,8 @@ extension AppDestination {
             CustomerCenterView()
         case .recordList(let placeId):
             RecordListView(placeId: placeId)
+        case .recordWrite(let placeId, let placeName):
+            RecordWriteView(placeId: placeId, placeName: placeName)
         case .aiRecommend:
             AIRecommendPromptView()
         }

--- a/Solply/Solply/Global/Coordinator/Destination/AppDestination.swift
+++ b/Solply/Solply/Global/Coordinator/Destination/AppDestination.swift
@@ -22,7 +22,7 @@ enum AppDestination: Hashable {
     case register
     case registerComplete
     case customerCenter
-    case recordList(placeId: Int)
+    case recordList(placeId: Int, placeName: String)
     case recordWrite(placeId: Int, placeName: String)
     case aiRecommend
 }
@@ -59,8 +59,8 @@ extension AppDestination {
             RegisterCompleteView()
         case .customerCenter:
             CustomerCenterView()
-        case .recordList(let placeId):
-            RecordListView(placeId: placeId)
+        case .recordList(let placeId, let placeName):
+            RecordListView(placeId: placeId, placeName: placeName)
         case .recordWrite(let placeId, let placeName):
             RecordWriteView(placeId: placeId, placeName: placeName)
         case .aiRecommend:

--- a/Solply/Solply/Global/Util/PhotoUploadManager.swift
+++ b/Solply/Solply/Global/Util/PhotoUploadManager.swift
@@ -1,0 +1,133 @@
+//
+//  PhotoUploadManager.swift
+//  Solply
+//
+//  Created by 김승원 on 4/12/26.
+//
+
+import Foundation
+
+@MainActor
+final class PhotoUploadManager {
+    
+    // MARK: - Singleton
+    
+    static let shared = PhotoUploadManager()
+    private init() {}
+    
+    // MARK: - Properties
+    
+    private let fileService = FileService()
+    private let uploadPhotosService = UploadPhotosService()
+    
+    // MARK: - Functions
+    
+    /// 이미지 데이터를 받아 S3에 업로드하고 imageKey 문자열 배열을 반환합니다.
+    /// 업로드 실패 시 빈 배열을 반환합니다.
+    ///
+    /// 1. Presigned URL 요청
+    /// 2. URL-Data 딕셔너리 생성
+    /// 3. 이미지 업로드
+    /// 4. ImageKey 가공
+    ///
+    /// - Parameter imageDatas: 업로드할 이미지의 파일명 & Data 튜플 배열
+    /// - Returns: S3에 업로드된 이미지의 key 문자열 배열
+    func upload(imageDatas: [(fileName: String, data: Data)]) async -> [String] {
+        guard !imageDatas.isEmpty else {
+            log("업로드할 이미지가 없습니다")
+            return []
+        }
+        
+        log("🌐 이미지 업로드 시작 - 이미지 수 \(imageDatas.count)")
+        
+        do {
+            let presignedInformation = try await fetchPresignedURLs(
+                imageDatas: imageDatas
+            )
+            
+            let presignedDictionary = makePresignedDictionary(
+                presignedInformation: presignedInformation,
+                imageDatas: imageDatas
+            )
+            
+            let imageKeys = try await uploadImages(
+                presignedDictionary: presignedDictionary
+            )
+            
+            let imageKeyStrings = makeImageKeyStrings(imageKeys: imageKeys)
+            
+            log("✅ 이미지 업로드 성공 - imageKeys: \(imageKeyStrings)")
+            return imageKeyStrings
+        } catch {
+            log("❌ 이미지 업로드 실패 - error: \(error)")
+            return []
+        }
+    }
+}
+
+// MARK: - Private Functions
+
+private extension PhotoUploadManager {
+    
+    /// Presigned URL을 서버에 요청합니다.
+    /// - Parameter imageDatas: 업로드할 이미지의 파일명 & Data 튜플 배열
+    /// - Returns: 서버로부터 받은 Presigned URL 정보 배열
+    func fetchPresignedURLs(
+        imageDatas: [(fileName: String, data: Data)]
+    ) async throws -> [PresignedUrlInformation] {
+        log("Presigned URL 요청 시작 - 파일명: \(imageDatas.map { $0.fileName })")
+        let request = PresignedUrlRequestDTO(
+            files: imageDatas.map { File(fileName: $0.fileName) }
+        )
+        let response = try await fileService.submitPresignedUrlRequest(request: request)
+        
+        guard let presignedInformation = response.data?.presignedGetUrlInfos else {
+            log("Presigned URL 응답 데이터 없음")
+            return []
+        }
+        
+        log("Presigned URL 요청 완료 - URL 수: \(presignedInformation.count)")
+        return presignedInformation
+    }
+    
+    /// Presigned URL 정보와 이미지 Data를 매핑하여 딕셔너리를 생성합니다.
+    ///  - Parameters:
+    ///    - presignedInformation: 서버로부터 받은 Presigned URL 정보 배열
+    ///    - imageDatas: 업로드할 이미지의 파일명 & Data 튜플 배열
+    ///  - Returns: Presigned URL을 key로, 이미지 Data를 value로 하는 딕셔너리
+    func makePresignedDictionary(
+        presignedInformation: [PresignedUrlInformation],
+        imageDatas: [(fileName: String, data: Data)]
+    ) -> [URL: Data] {
+        var dictionary: [URL: Data] = [:]
+        
+        for (info, imageData) in zip(presignedInformation, imageDatas) {
+            if let url = URL(string: info.presignedUrl) {
+                dictionary[url] = imageData.data
+            }
+        }
+        
+        return dictionary
+    }
+    
+    /// Presigned URL을 통해 S3에 이미지를 업로드합니다.
+    ///  - Parameter presignedDictionary: Presigned URL을 key로, 이미지 Data를 value로 하는 딕셔너리
+    ///  - Returns: 업로드된 이미지의 S3 URL 배열
+    func uploadImages(presignedDictionary: [URL: Data]) async throws -> [URL] {
+        log("S3 업로드 시작 - 이미지 수: \(presignedDictionary.count)")
+        let imageKeys = try await uploadPhotosService.uploadImages(presignedDictionary)
+        log("S3 업로드 완료 - imageKey 수: \(imageKeys.count)")
+        return imageKeys
+    }
+    
+    /// S3 URL 배열을 imageKey 문자열 배열로 가공합니다.
+    ///  - Parameter imageKeys: 업로드된 이미지의 S3 URL 배열
+    ///  - Returns: truncate 처리된 imageKey 문자열 배열
+    func makeImageKeyStrings(imageKeys: [URL]) -> [String] {
+        return imageKeys.map { $0.absoluteString.truncatedForS3() }
+    }
+    
+    func log(_ text: String) {
+        print("📸 [PhotoUploadManager] \(text)")
+    }
+}

--- a/Solply/Solply/Network/API/PlaceAPI.swift
+++ b/Solply/Solply/Network/API/PlaceAPI.swift
@@ -51,7 +51,7 @@ protocol PlaceAPI {
     func submitRegister(request: RegisterRequestDTO) async throws -> BaseResponseBody<RegisterResponseDTO>
     
     /// 장소 리뷰(기록) 작성
-    // TODO: - 장소 리뷰 API 추가
+    func submitPlaceRecordWrite(request: PlaceRecordWriteRequestDTO) async throws -> BaseResponseBody<EmptyResponseDTO>
     
     /// 장소 리뷰(기록) 리스트 조회
     func fetchPlaceRecordList(placeId: Int) async throws -> BaseResponseBody<PlaceRecordListResponseDTO>

--- a/Solply/Solply/Network/DTO/Place/RequestDTO/PlaceRecordWriteRequestDTO.swift
+++ b/Solply/Solply/Network/DTO/Place/RequestDTO/PlaceRecordWriteRequestDTO.swift
@@ -1,0 +1,16 @@
+//
+//  PlaceRecordWriteRequestDTO.swift
+//  Solply
+//
+//  Created by 김승원 on 4/12/26.
+//
+
+import Foundation
+
+struct PlaceRecordWriteRequestDTO: RequestModelType {
+    let placeId: Int
+    let visitedAt: String
+    let visitTimeSlot: VisitTime
+    let content: String
+    let imageKeys: [String]
+}

--- a/Solply/Solply/Network/Service/PlaceService.swift
+++ b/Solply/Solply/Network/Service/PlaceService.swift
@@ -77,7 +77,11 @@ extension PlaceService: PlaceAPI {
         return try await self.request(with: .submitRegister(request: request))
     }
     
-    // TODO: - 장소 기록 작성 API
+    func submitPlaceRecordWrite(
+        request: PlaceRecordWriteRequestDTO
+    ) async throws -> BaseResponseBody<EmptyResponseDTO> {
+        return try await self.request(with: .submitPlaceRecordWrite(request: request))
+    }
     
     func fetchPlaceRecordList(placeId: Int) async throws -> BaseResponseBody<PlaceRecordListResponseDTO> {
         return try await self.request(with: .fetchPlaceRecordList(placeId: placeId))

--- a/Solply/Solply/Network/Service/UploadPhotosService.swift
+++ b/Solply/Solply/Network/Service/UploadPhotosService.swift
@@ -12,7 +12,6 @@ final class UploadPhotosService { }
 extension UploadPhotosService: UploadPhotosAPI {
     func uploadImages(_ dictionary: [URL: Data]) async throws -> [URL] {
         var uploadedUrls: [URL] = []
-        print("📷 [UploadPhotosService] S3 사진 업로드 시작")
         try await withThrowingTaskGroup(of: URL.self) { group in
             for (presignedUrl, data) in dictionary {
                 group.addTask {
@@ -25,7 +24,6 @@ extension UploadPhotosService: UploadPhotosAPI {
                 uploadedUrls.append(url)
             }
         }
-        print("📸 [UploadPhotosService] S3 사진 업로드 완료")
         return uploadedUrls
     }
     

--- a/Solply/Solply/Network/TargetType/PlaceTargetType.swift
+++ b/Solply/Solply/Network/TargetType/PlaceTargetType.swift
@@ -25,7 +25,7 @@ enum PlaceTargetType {
     case searchPlace(placeName: String)
     case submitReports(placeId: Int, request: ReportsRequestDTO)
     case submitRegister(request: RegisterRequestDTO)
-    // TODO: - 장소 기록 작성 API
+    case submitPlaceRecordWrite(request: PlaceRecordWriteRequestDTO)
     case fetchPlaceRecordList(placeId: Int)
 }
 
@@ -54,6 +54,8 @@ extension PlaceTargetType: BaseTargetType {
             return "/places/\(placeId)/reports"
         case .submitRegister:
             return "/places/requests"
+        case .submitPlaceRecordWrite:
+            return "/places/reviews"
         case .fetchPlaceRecordList(let placeId):
             return "/places/reviews/\(placeId)/reviews"
         }
@@ -70,6 +72,7 @@ extension PlaceTargetType: BaseTargetType {
         case .searchPlace: return .get
         case .submitReports: return .post
         case .submitRegister: return .post
+        case .submitPlaceRecordWrite: return .post
         case .fetchPlaceRecordList: return .get
         }
     }
@@ -123,6 +126,8 @@ extension PlaceTargetType: BaseTargetType {
         case .submitReports(_, let request):
             return .requestJSONEncodable(request)
         case .submitRegister(let request):
+            return .requestJSONEncodable(request)
+        case .submitPlaceRecordWrite(let request):
             return .requestJSONEncodable(request)
         case .fetchPlaceRecordList:
             return .requestPlain

--- a/Solply/Solply/Presentation/MyPage/MyPageEdit/Effect/MyPageEditEffect.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPageEdit/Effect/MyPageEditEffect.swift
@@ -9,17 +9,9 @@ import Foundation
 
 struct MyPageEditEffect {
     private let userService: UserAPI
-    private let fileService: FileAPI
-    private let uploadPhotosService: UploadPhotosAPI
     
-    init(
-        userService: UserAPI,
-        fileService: FileAPI,
-        uploadPhotosService: UploadPhotosAPI
-    ) {
+    init(userService: UserAPI,) {
         self.userService = userService
-        self.fileService = fileService
-        self.uploadPhotosService = uploadPhotosService
     }
 }
 
@@ -57,48 +49,6 @@ extension MyPageEditEffect {
             
         } catch {
             return .updateUserInformationFailed(error: .unknownError)
-        }
-    }
-}
-
-// MARK: - FileAPI
-
-extension MyPageEditEffect {
-    func submitPresignedUrlRequest(request: PresignedUrlRequestDTO) async -> MyPageEditAction {
-        do {
-            let response = try await fileService.submitPresignedUrlRequest(request: request)
-            
-            guard let data = response.data,
-                  let presignedUrl = data.presignedGetUrlInfos.first?.presignedUrl else {
-                return .submitPresignedUrlRequestFailed(error: .responseError)
-            }
-            
-            return .submitPresignedUrlRequestSuccess(presignedUrl: presignedUrl)
-        } catch let error as NetworkError {
-            return .submitPresignedUrlRequestFailed(error: error)
-        } catch {
-            return .submitPresignedUrlRequestFailed(error: .unknownError)
-        }
-    }
-}
-
-// MARK: - UploadPhotoAPI
-
-extension MyPageEditEffect {
-    func uploadImage(dictionary: [URL: Data]) async -> MyPageEditAction {
-        do {
-            let response = try await uploadPhotosService.uploadImages(dictionary)
-            
-            guard let imageKey = response.first else {
-                return .photoUploadFailed(error: .responseError)
-            }
-            
-            return .photoUploadSuccess(imageKey: imageKey)
-            
-        } catch let error as NetworkError {
-            return .photoUploadFailed(error: error)
-        } catch {
-            return .photoUploadFailed(error: .unknownError)
         }
     }
 }

--- a/Solply/Solply/Presentation/MyPage/MyPageEdit/Intent/MyPageEditAction.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPageEdit/Intent/MyPageEditAction.swift
@@ -25,12 +25,4 @@ enum MyPageEditAction {
     case updateUserInformation(imageKeyString: String?)
     case updateUserInformationSuccess(nickName: String, persona: String)
     case updateUserInformationFailed(error: NetworkError)
-    
-    // uploadImage
-    case submitPresignedUrlRequest(request: PresignedUrlRequestDTO)
-    case submitPresignedUrlRequestSuccess(presignedUrl: String)
-    case submitPresignedUrlRequestFailed(error: NetworkError)
-    
-    case photoUploadSuccess(imageKey: URL)
-    case photoUploadFailed(error: NetworkError)
 }

--- a/Solply/Solply/Presentation/MyPage/MyPageEdit/Intent/MyPageEditStore.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPageEdit/Intent/MyPageEditStore.swift
@@ -21,15 +21,10 @@ final class MyPageEditStore: ObservableObject {
     // MARK: - Initializer
     
     init(
-        effect: MyPageEditEffect = MyPageEditEffect(
-            userService: UserService(),
-            fileService: FileService(),
-            uploadPhotosService: UploadPhotosService()
-        ),
         userInformation: UserInformation,
     ) {
-        self.effect = effect
         self.userInformation = userInformation
+        self.effect = MyPageEditEffect(userService: UserService())
     }
     
     // MARK: - Dispatch
@@ -50,46 +45,17 @@ final class MyPageEditStore: ObservableObject {
             }
             
         case .startUpdateUserInformation:
-            if let attachedImageData = state.attachedImageData {
-                if attachedImageData.0.isEmpty {
-                    self.dispatch(.updateUserInformation(imageKeyString: ""))
-                } else {
-                    self.dispatch(
-                        .submitPresignedUrlRequest(
-                            request: PresignedUrlRequestDTO(
-                                files: [File(fileName: attachedImageData.0)]
-                            )
-                        )
+            Task {
+                if let attachedImageData = state.attachedImageData {
+                    let imageKeyStrings = await PhotoUploadManager.shared.upload(
+                        imageDatas: [attachedImageData]
                     )
+                    
+                    self.dispatch(.updateUserInformation(imageKeyString: imageKeyStrings.first ?? ""))
+                } else {
+                    self.dispatch(.updateUserInformation(imageKeyString: nil))
                 }
-            } else {
-                self.dispatch(.updateUserInformation(imageKeyString: nil))
             }
-            
-        case .submitPresignedUrlRequest(let request):
-            Task {
-                let result = await effect.submitPresignedUrlRequest(request: request)
-                self.dispatch(result)
-            }
-            
-        case .submitPresignedUrlRequestSuccess(let presignedUrl):
-            guard let attachedImageData = state.attachedImageData else { return }
-            
-            var presignedDictionary: [URL: Data] = [:]
-            
-            if let url = URL(string: presignedUrl) {
-                presignedDictionary[url] = attachedImageData.1
-            }
-            
-            Task {
-                let result = await effect.uploadImage(dictionary: presignedDictionary)
-                self.dispatch(result)
-            }
-            
-        case .photoUploadSuccess(let imageKey):
-            let imageKeyString = imageKey.absoluteString.truncatedForS3()
-            
-            self.dispatch(.updateUserInformation(imageKeyString: imageKeyString))
             
         case .updateUserInformation(let imageKeyString):
             let nickname = state.nickname.isEmpty ? userInformation.nickname : state.nickname

--- a/Solply/Solply/Presentation/MyPage/MyPageEdit/State/MyPageEditReducer.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPageEdit/State/MyPageEditReducer.swift
@@ -64,24 +64,6 @@ enum MyPageEditReducer {
             print(error)
             state.isCompleteButtonLoading = false
             break
-            
-        case .submitPresignedUrlRequest:
-            break
-            
-        case .submitPresignedUrlRequestSuccess:
-            break
-            
-        case .submitPresignedUrlRequestFailed(let error):
-            print(error)
-            break
-            
-        case .photoUploadSuccess:
-            print("S3 사진 업로드 성공")
-            break
-            
-        case .photoUploadFailed(let error):
-            print("S3 사진 업로드 실패 error: \(error)")
-            break
         }
     }
 }

--- a/Solply/Solply/Presentation/Place/PlaceDetail/View/PlaceDetailView.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/View/PlaceDetailView.swift
@@ -371,7 +371,7 @@ extension PlaceDetailView {
             sectionHeader(
                 title: "기록",
                 moreButtonAction: {
-                    appCoordinator.navigate(to: .recordList(placeId: store.placeId))
+                    appCoordinator.navigate(to: .recordList(placeId: store.placeId, placeName: store.state.placeName))
                 },
                 isButtonEnabled: store.state.isMoreRecordsButtonEnabled
             )

--- a/Solply/Solply/Presentation/Place/PlaceDetail/View/PlaceDetailView.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/View/PlaceDetailView.swift
@@ -379,7 +379,7 @@ extension PlaceDetailView {
             
             RecordWriteButton {
                 appState.requireLoginWithAlert(
-                    onAuthenticated: { /* TODO: - 기록작성 뷰 넘기기 */ },
+                    onAuthenticated: { appCoordinator.navigate(to: .recordWrite(placeId: store.placeId, placeName: store.state.placeName)) },
                     onExplore: { appCoordinator.changeRoot(to: .auth) }
                 )
             }

--- a/Solply/Solply/Presentation/Record/RecordList/Intent/RecordListStore.swift
+++ b/Solply/Solply/Presentation/Record/RecordList/Intent/RecordListStore.swift
@@ -16,6 +16,7 @@ final class RecordListStore: ObservableObject {
     private let effect: RecordListEffect
     
     let placeId: Int
+    let placeName: String
     
     // MARK: - Initializer
     
@@ -23,10 +24,12 @@ final class RecordListStore: ObservableObject {
         effect: RecordListEffect = RecordListEffect(
             placeService: PlaceService()
         ),
-        placeId: Int
+        placeId: Int,
+        placeName: String
     ) {
         self.effect = effect
         self.placeId = placeId
+        self.placeName = placeName
     }
     
     // MARK: - dispatch

--- a/Solply/Solply/Presentation/Record/RecordList/View/RecordListView.swift
+++ b/Solply/Solply/Presentation/Record/RecordList/View/RecordListView.swift
@@ -17,8 +17,8 @@ struct RecordListView: View {
     
     // MARK: - Initializer
     
-    init(placeId: Int) {
-        self._store = StateObject(wrappedValue: RecordListStore(placeId: placeId))
+    init(placeId: Int, placeName: String) {
+        self._store = StateObject(wrappedValue: RecordListStore(placeId: placeId, placeName: placeName))
     }
     
     // MARK: - Body
@@ -27,7 +27,7 @@ struct RecordListView: View {
         ScrollView(.vertical, showsIndicators: true) {
             VStack(alignment: .center, spacing: 20.adjustedHeight) {
                 RecordWriteButton {
-                    // TODO: - 기록 작성하기 뷰 연결
+                    appCoordinator.navigate(to: .recordWrite(placeId: store.placeId, placeName: store.placeName)) 
                 }
                 
                 recordList

--- a/Solply/Solply/Presentation/Record/RecordWrite/Effect/RecordWriteEffect.swift
+++ b/Solply/Solply/Presentation/Record/RecordWrite/Effect/RecordWriteEffect.swift
@@ -1,0 +1,33 @@
+//
+//  RecordWriteEffect.swift
+//  Solply
+//
+//  Created by 김승원 on 4/12/26.
+//
+
+import Foundation
+
+struct RecordWriteEffect {
+    private let placeService: PlaceAPI
+    
+    init(placeService: PlaceAPI) {
+        self.placeService = placeService
+    }
+}
+
+// MARK: - PlaceAPI
+
+extension RecordWriteEffect {
+    func submitPlaceRecordWrite(request: PlaceRecordWriteRequestDTO) async -> RecordWriteAction {
+        do {
+            let _ = try await placeService.submitPlaceRecordWrite(request: request)
+            
+            return .submitPlaceRecordWriteSuccess
+            
+        } catch let error as NetworkError {
+            return .submitPlaceRecordWriteFailed(error: error)
+        } catch {
+            return .submitPlaceRecordWriteFailed(error: .unknownError)
+        }
+    }
+}

--- a/Solply/Solply/Presentation/Record/RecordWrite/Intent/RecordWriteAction.swift
+++ b/Solply/Solply/Presentation/Record/RecordWrite/Intent/RecordWriteAction.swift
@@ -11,6 +11,12 @@ enum RecordWriteAction {
     case selectDate(Date?)
     case selectVisitTime(VisitTime)
     case writeRecordText(String)
+    case selectPhotos([(fileName: String, data: Data)])
     
-    case selectTime([(fileName: String, data: Data)])
+    case registerRecordButtonTapped
+    
+    // api
+    case submitPlaceRecordWrite(request: PlaceRecordWriteRequestDTO)
+    case submitPlaceRecordWriteSuccess
+    case submitPlaceRecordWriteFailed(error: NetworkError)
 }

--- a/Solply/Solply/Presentation/Record/RecordWrite/Intent/RecordWriteStore.swift
+++ b/Solply/Solply/Presentation/Record/RecordWrite/Intent/RecordWriteStore.swift
@@ -36,15 +36,21 @@ final class RecordWriteStore: ObservableObject {
             guard let vistedAt = state.selectedDate?.yyyyMMddString,
                   let visitTimeSlot = state.selectedVisitTime else { return }
             
-            let request = PlaceRecordWriteRequestDTO(
-                placeId: placeId,
-                visitedAt: vistedAt,
-                visitTimeSlot: visitTimeSlot,
-                content: state.recordText,
-                imageKeys: [] // 임시 빈배열
-            )
-            
-            dispatch(.submitPlaceRecordWrite(request: request))
+            Task {
+                let imageKeyStrings = await PhotoUploadManager.shared.upload(
+                    imageDatas: state.selectedPhotos
+                )
+                
+                let request = PlaceRecordWriteRequestDTO(
+                    placeId: placeId,
+                    visitedAt: vistedAt,
+                    visitTimeSlot: visitTimeSlot,
+                    content: state.recordText,
+                    imageKeys: imageKeyStrings
+                )
+                
+                dispatch(.submitPlaceRecordWrite(request: request))
+            }
             
         case .submitPlaceRecordWrite(let request):
             Task {

--- a/Solply/Solply/Presentation/Record/RecordWrite/Intent/RecordWriteStore.swift
+++ b/Solply/Solply/Presentation/Record/RecordWrite/Intent/RecordWriteStore.swift
@@ -13,6 +13,8 @@ final class RecordWriteStore: ObservableObject {
     // MARK: - Properties
     
     @Published private(set) var state = RecordWriteState()
+    private let effect: RecordWriteEffect
+    
     let placeId: Int
     let placeName: String
     
@@ -21,6 +23,7 @@ final class RecordWriteStore: ObservableObject {
     init(placeId: Int, placeName: String) {
         self.placeId = placeId
         self.placeName = placeName
+        self.effect = RecordWriteEffect(placeService: PlaceService())
     }
     
     // MARK: - Dispatch
@@ -29,6 +32,26 @@ final class RecordWriteStore: ObservableObject {
         RecordWriteReducer.reduce(state: &state, action: action)
         
         switch action {
+        case .registerRecordButtonTapped:
+            guard let vistedAt = state.selectedDate?.yyyyMMddString,
+                  let visitTimeSlot = state.selectedVisitTime else { return }
+            
+            let request = PlaceRecordWriteRequestDTO(
+                placeId: placeId,
+                visitedAt: vistedAt,
+                visitTimeSlot: visitTimeSlot,
+                content: state.recordText,
+                imageKeys: [] // 임시 빈배열
+            )
+            
+            dispatch(.submitPlaceRecordWrite(request: request))
+            
+        case .submitPlaceRecordWrite(let request):
+            Task {
+                let result = await effect.submitPlaceRecordWrite(request: request)
+                dispatch(result)
+            }
+            
         default:
             break
         }

--- a/Solply/Solply/Presentation/Record/RecordWrite/Intent/RecordWriteStore.swift
+++ b/Solply/Solply/Presentation/Record/RecordWrite/Intent/RecordWriteStore.swift
@@ -12,12 +12,15 @@ final class RecordWriteStore: ObservableObject {
     
     // MARK: - Properties
     
-    @Published private(set) var state: RecordWriteState
+    @Published private(set) var state = RecordWriteState()
+    let placeId: Int
+    let placeName: String
     
     // MARK: - Initializer
     
-    init(placeName: String) {
-        self.state = RecordWriteState(placeName: placeName)
+    init(placeId: Int, placeName: String) {
+        self.placeId = placeId
+        self.placeName = placeName
     }
     
     // MARK: - Dispatch

--- a/Solply/Solply/Presentation/Record/RecordWrite/State/RecordWriteReducer.swift
+++ b/Solply/Solply/Presentation/Record/RecordWrite/State/RecordWriteReducer.swift
@@ -20,8 +20,22 @@ enum RecordWriteReducer {
         case .writeRecordText(let text):
             state.recordText = text
             
-        case .selectTime(let photos):
+        case .selectPhotos(let photos):
             state.selectedPhotos = photos
+            
+        case .registerRecordButtonTapped:
+            break
+            
+        // api
+        case .submitPlaceRecordWrite:
+            break
+            
+        case .submitPlaceRecordWriteSuccess:
+            state.shouldGoBack = true
+            
+        case .submitPlaceRecordWriteFailed(let error):
+            print(error)
+            break
         }
     }
 }

--- a/Solply/Solply/Presentation/Record/RecordWrite/State/RecordWriteState.swift
+++ b/Solply/Solply/Presentation/Record/RecordWrite/State/RecordWriteState.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 struct RecordWriteState {
+    var shouldGoBack: Bool = false
+    
     var selectedDate: Date? = nil
     var selectedVisitTime: VisitTime? = nil
     var recordText: String = ""

--- a/Solply/Solply/Presentation/Record/RecordWrite/State/RecordWriteState.swift
+++ b/Solply/Solply/Presentation/Record/RecordWrite/State/RecordWriteState.swift
@@ -8,16 +8,13 @@
 import Foundation
 
 struct RecordWriteState {
-    var placeName: String
-    
     var selectedDate: Date? = nil
     var selectedVisitTime: VisitTime? = nil
     var recordText: String = ""
     var selectedPhotos: [(fileName: String, data: Data)] = []
     
     var isSubmitButtonEnabled: Bool {
-        !placeName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        && selectedDate != nil
+        selectedDate != nil
         && selectedVisitTime != nil
         && !recordText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }

--- a/Solply/Solply/Presentation/Record/RecordWrite/View/RecordWriteView.swift
+++ b/Solply/Solply/Presentation/Record/RecordWrite/View/RecordWriteView.swift
@@ -16,9 +16,9 @@ struct RecordWriteView: View {
     
     // MARK: - Initializer
     
-    init(placeName: String) {
+    init(placeId: Int, placeName: String) {
         _store = StateObject(
-            wrappedValue: RecordWriteStore(placeName: placeName)
+            wrappedValue: RecordWriteStore(placeId: placeId, placeName: placeName)
         )
     }
     
@@ -73,11 +73,10 @@ struct RecordWriteView: View {
                 .padding(.top, 14.adjustedHeight)
             }
             .padding(.horizontal, 20.adjustedWidth)
-            .padding(.bottom, 100.adjustedHeight)
+            .padding(.bottom, 124.adjustedHeight)
         }
         .overlay(alignment: .bottom) {
             aiRecommendButton
-                .padding(.horizontal, 20.adjustedWidth)
                 .padding(.bottom, 4.adjustedHeight)
         }
         .customNavigationBar(.backWithTitle(title: "혼놀 기록 남기기") {
@@ -93,7 +92,7 @@ extension RecordWriteView {
     
     private var placeField: some View {
         HStack(alignment: .center, spacing: 0) {
-            Text(store.state.placeName)
+            Text(store.placeName)
                 .applySolplyFont(.body_16_r)
                 .foregroundStyle(.coreBlack)
             

--- a/Solply/Solply/Presentation/Record/RecordWrite/View/RecordWriteView.swift
+++ b/Solply/Solply/Presentation/Record/RecordWrite/View/RecordWriteView.swift
@@ -67,7 +67,7 @@ struct RecordWriteView: View {
                     RecordWriteSectionHeader(title: "사진 추가 (선택)")
                     
                     SolplyPhotosPicker { imageData in
-                        store.dispatch(.selectTime(imageData))
+                        store.dispatch(.selectPhotos(imageData))
                     }
                 }
                 .padding(.top, 14.adjustedHeight)
@@ -76,12 +76,17 @@ struct RecordWriteView: View {
             .padding(.bottom, 124.adjustedHeight)
         }
         .overlay(alignment: .bottom) {
-            aiRecommendButton
+            registerRecordButton
                 .padding(.bottom, 4.adjustedHeight)
         }
         .customNavigationBar(.backWithTitle(title: "혼놀 기록 남기기") {
             appCoordinator.goBack()
         })
+        .onChange(of: store.state.shouldGoBack) { _, shouldGoBack in
+            if shouldGoBack {
+                appCoordinator.goBack()
+            }
+        }
         .customModal()
     }
 }
@@ -138,11 +143,13 @@ extension RecordWriteView {
         }
     }
     
-    private var aiRecommendButton: some View {
+    private var registerRecordButton: some View {
         SolplyMainButton(
             title: "등록하기",
             isEnabled: store.state.isSubmitButtonEnabled
-        )
+        ) {
+            store.dispatch(.registerRecordButtonTapped)
+        }
         .padding(.horizontal, 20.adjustedWidth)
         .padding(.top, 12.adjustedHeight)
         .padding(.bottom, 4.adjustedHeight)

--- a/Solply/Solply/Presentation/Register/Effect/RegisterEffect.swift
+++ b/Solply/Solply/Presentation/Register/Effect/RegisterEffect.swift
@@ -11,21 +11,15 @@ struct RegisterEffect {
     private let tagsService: TagsAPI
     private let naverPlaceSearchService: NaverPlaceSearchAPI
     private let placeService: PlaceAPI
-    private let fileService: FileAPI
-    private let uploadPhotosService: UploadPhotosAPI
     
     init(
         tagsService: TagsAPI,
         naverPlaceSearchService: NaverPlaceSearchAPI,
         placeService: PlaceAPI,
-        fileService: FileAPI,
-        uploadPhotosService: UploadPhotosAPI
     ) {
         self.tagsService = tagsService
         self.naverPlaceSearchService = naverPlaceSearchService
         self.placeService = placeService
-        self.fileService = fileService
-        self.uploadPhotosService = uploadPhotosService
     }
 }
 
@@ -97,43 +91,6 @@ extension RegisterEffect {
             return .submitRegisterFailed(error: error)
         } catch {
             return .submitRegisterFailed(error: .unknownError)
-        }
-    }
-}
-
-// MARK: - FileAPI
-
-extension RegisterEffect {
-    func submitPresignedUrlRequest(request: PresignedUrlRequestDTO) async -> RegisterAction {
-        do {
-            let response = try await fileService.submitPresignedUrlRequest(request: request)
-            
-            guard let data = response.data else {
-                return .submitPresignedUrlRequestFailed(error: .responseError)
-            }
-            
-            return .presignedUrlRequestSubmitted(response: data)
-            
-        } catch let error as NetworkError {
-            return .submitPresignedUrlRequestFailed(error: error)
-        } catch {
-            return .submitPresignedUrlRequestFailed(error: .unknownError)
-        }
-    }
-}
-
-// MARK: - UploadPhotoAPI
-
-extension RegisterEffect {
-    func uploadImages(dictionary: [URL: Data]) async -> RegisterAction {
-        do {
-            let response = try await uploadPhotosService.uploadImages(dictionary)
-            
-            return .photoUploadSuccess(imageKeys: response)
-        } catch let error as NetworkError {
-            return .photoUploadFailed(error: error)
-        } catch {
-            return .photoUploadFailed(error: .unknownError)
         }
     }
 }

--- a/Solply/Solply/Presentation/Register/Intent/RegisterAction.swift
+++ b/Solply/Solply/Presentation/Register/Intent/RegisterAction.swift
@@ -30,11 +30,4 @@ enum RegisterAction {
     case submitRegister(imageKeyStrings: [String])
     case registerSubmitted
     case submitRegisterFailed(error: NetworkError)
-    
-    case submitPresignedUrlRequest(request: PresignedUrlRequestDTO)
-    case presignedUrlRequestSubmitted(response: PresignedUrlResponseDTO)
-    case submitPresignedUrlRequestFailed(error: NetworkError)
-    
-    case photoUploadSuccess(imageKeys: [URL])
-    case photoUploadFailed(error: NetworkError)
 }

--- a/Solply/Solply/Presentation/Register/Intent/RegisterStore.swift
+++ b/Solply/Solply/Presentation/Register/Intent/RegisterStore.swift
@@ -13,9 +13,7 @@ final class RegisterStore: ObservableObject {
     private let effect = RegisterEffect(
         tagsService: TagsService(),
         naverPlaceSearchService: NaverPlaceSearchService(),
-        placeService: PlaceService(),
-        fileService: FileService(),
-        uploadPhotosService: UploadPhotosService()
+        placeService: PlaceService()
     )
     
     func dispatch(_ action: RegisterAction) {
@@ -24,52 +22,12 @@ final class RegisterStore: ObservableObject {
         switch action {
             
         case .startRegister:
-            if state.attachedImageData.isEmpty {
-                self.dispatch(.submitRegister(imageKeyStrings: []))
-            } else {
-                dispatch(
-                    .submitPresignedUrlRequest(
-                        request: PresignedUrlRequestDTO(
-                            files: state.attachedImageData.map { fileName, _ in
-                                File(fileName: fileName)
-                                
-                            }
-                        )
-                    )
+            Task {
+                let imageKeyStrings = await PhotoUploadManager.shared.upload(
+                    imageDatas: state.attachedImageData
                 )
+                self.dispatch(.submitRegister(imageKeyStrings: imageKeyStrings))
             }
-            
-        case .submitPresignedUrlRequest(let request):
-            Task {
-                let result = await effect.submitPresignedUrlRequest(request: request)
-                self.dispatch(result)
-            }
-            
-        case .presignedUrlRequestSubmitted(let response):
-            let presignedInformation = response.presignedGetUrlInfos
-            let imageDatas = state.attachedImageData
-
-            var presignedDictionary: [URL: Data] = [:]
-
-            for (info, data) in zip(presignedInformation, imageDatas) {
-                if let url = URL(string: info.presignedUrl) {
-                    presignedDictionary[url] = data.1
-                }
-            }
-            
-            Task {
-                let result = await effect.uploadImages(dictionary: presignedDictionary)
-                self.dispatch(result)
-            }
-            
-        case .photoUploadSuccess(let imageKeys):
-            var imageKeyStrings: [String]
-            
-            imageKeyStrings = imageKeys.map { imageKey in
-                imageKey.absoluteString.truncatedForS3()
-            }
-            
-            self.dispatch(.submitRegister(imageKeyStrings: imageKeyStrings))
             
         case .fetchSubTags(let parentId):
             Task {

--- a/Solply/Solply/Presentation/Register/Intent/RegisterStore.swift
+++ b/Solply/Solply/Presentation/Register/Intent/RegisterStore.swift
@@ -23,9 +23,7 @@ final class RegisterStore: ObservableObject {
             
         case .startRegister:
             Task {
-                let imageKeyStrings = await PhotoUploadManager.shared.upload(
-                    imageDatas: state.attachedImageData
-                )
+                let imageKeyStrings = await PhotoUploadManager.shared.upload(imageDatas: state.attachedImageData)
                 self.dispatch(.submitRegister(imageKeyStrings: imageKeyStrings))
             }
             

--- a/Solply/Solply/Presentation/Register/State/RegisterReducer.swift
+++ b/Solply/Solply/Presentation/Register/State/RegisterReducer.swift
@@ -76,24 +76,6 @@ enum RegisterReducer {
         case .submitRegisterFailed(let error):
             print(error)
             break
-            
-        case .submitPresignedUrlRequest:
-            break
-            
-        case .presignedUrlRequestSubmitted:
-            break
-            
-        case .submitPresignedUrlRequestFailed(let error):
-            print(error)
-            break
-            
-        case .photoUploadSuccess:
-            print("S3 사진 업로드 성공")
-            break
-            
-        case .photoUploadFailed(let error):
-            print("S3 사진 업로드 실패 error: \(error)")
-            break
         }
     }
 }

--- a/Solply/Solply/Presentation/Reports/Effect/ReportsEffect.swift
+++ b/Solply/Solply/Presentation/Reports/Effect/ReportsEffect.swift
@@ -8,55 +8,12 @@
 import Foundation
 
 struct ReportsEffect {
-    private let fileService: FileAPI
-    private let uploadPhotosService: UploadPhotosAPI
     private let placeService: PlaceAPI
     
     init(
-        fileService: FileAPI,
-        uploadPhotosService: UploadPhotosAPI,
         placeService: PlaceAPI
     ) {
-        self.fileService = fileService
-        self.uploadPhotosService = uploadPhotosService
         self.placeService = placeService
-    }
-}
-
-// MARK: - FileAPI
-
-extension ReportsEffect {
-    func submitPresignedUrlRequest(request: PresignedUrlRequestDTO) async -> ReportsAction {
-        do {
-            let response = try await fileService.submitPresignedUrlRequest(request: request)
-            
-            guard let data = response.data else {
-                return .errorOccured(error: .responseError)
-            }
-
-            return .presignedUrlRequestSubmitted(response: data)
-            
-        } catch let error as NetworkError {
-            return .errorOccured(error: error)
-        } catch {
-            return .errorOccured(error: .unknownError)
-        }
-    }
-}
-
-// MARK: - UploadPhotoAPI
-
-extension ReportsEffect {
-    func uploadImages(dictionary: [URL: Data]) async -> ReportsAction {
-        do {
-            let response = try await uploadPhotosService.uploadImages(dictionary)
-            
-            return .photoUploadSuccess(imageKeys: response)
-        } catch let error as NetworkError {
-            return .photoUploadFailed(error: error)
-        } catch {
-            return .photoUploadFailed(error: .unknownError)
-        }
     }
 }
 

--- a/Solply/Solply/Presentation/Reports/Intent/ReportsAction.swift
+++ b/Solply/Solply/Presentation/Reports/Intent/ReportsAction.swift
@@ -18,14 +18,7 @@ enum ReportsAction {
     // api
     case errorOccured(error: NetworkError)
     
-    case submitPresignedUrlRequest(request: PresignedUrlRequestDTO)
-    case presignedUrlRequestSubmitted(response: PresignedUrlResponseDTO)
-    
     case submitReports(placeId: Int, request: ReportsRequestDTO)
     case reportsSubmitted
     case reportsFailed(error: NetworkError)
-    
-    // 사진 업로드
-    case photoUploadSuccess(imageKeys: [URL])
-    case photoUploadFailed(error: NetworkError)
 }

--- a/Solply/Solply/Presentation/Reports/Intent/ReportsStore.swift
+++ b/Solply/Solply/Presentation/Reports/Intent/ReportsStore.swift
@@ -11,11 +11,7 @@ import Foundation
 final class ReportsStore: ObservableObject {
     
     @Published private(set) var state = ReportsState()
-    private let effect = ReportsEffect(
-        fileService: FileService(),
-        uploadPhotosService: UploadPhotosService(),
-        placeService: PlaceService()
-    )
+    private let effect = ReportsEffect(placeService: PlaceService())
     
     func dispatch(_ action: ReportsAction) {
         ReportsReducer.reduce(state: &state, action: action)
@@ -23,73 +19,26 @@ final class ReportsStore: ObservableObject {
         switch action {
             
         case .changeReportsStep(let reportsStep):
-            guard let placeId = state.placeId else { return }
-            
-            if let selectedReportsType = state.selectedReportsType, reportsStep == .reportsComplete {
-                if state.attachedImageData.isEmpty {
-                    dispatch(
-                        .submitReports(
-                            placeId: placeId,
-                            request: ReportsRequestDTO(
-                                reportType: selectedReportsType.rawValue,
-                                content: state.reportsContent,
-                                imageKeys: []
-                            )
-                        )
-                    )
-                } else {
-                    dispatch(
-                        .submitPresignedUrlRequest(
-                            request: PresignedUrlRequestDTO(
-                                files: state.attachedImageData.map { fileName, _ in
-                                    File(fileName: fileName)
-                                }
-                            )
-                        )
-                    )
-                }
-            }
-            
-        case .submitPresignedUrlRequest(let request):
-            Task {
-                let result = await effect.submitPresignedUrlRequest(request: request)
-                self.dispatch(result)
-            }
-            
-        case .presignedUrlRequestSubmitted(let response):
-            let presignedInformation = response.presignedGetUrlInfos
-            let imageDatas = state.attachedImageData
-
-            var presignedDictionary: [URL: Data] = [:]
-
-            for (info, data) in zip(presignedInformation, imageDatas) {
-                if let url = URL(string: info.presignedUrl) {
-                    presignedDictionary[url] = data.1
-                }
-            }
+            guard let placeId = state.placeId,
+                  let selectedReportsType = state.selectedReportsType,
+                  reportsStep == .reportsComplete else { return }
             
             Task {
-                let result = await effect.uploadImages(dictionary: presignedDictionary)
-                self.dispatch(result)
+                let imageKeyStrings = await PhotoUploadManager.shared.upload(
+                    imageDatas: state.attachedImageData
+                )
+                
+                self.dispatch(
+                    .submitReports(
+                        placeId: placeId,
+                        request: ReportsRequestDTO(
+                            reportType: selectedReportsType.rawValue,
+                            content: state.reportsContent,
+                            imageKeys: imageKeyStrings
+                        )
+                    )
+                )
             }
-            
-        case .photoUploadSuccess(let imageKeys):
-            guard let reportsType = state.selectedReportsType,
-                  let placeId = state.placeId else { return }
-            
-            var imageKeyStrings: [String]
-            
-            imageKeyStrings = imageKeys.map { imageKey in
-                imageKey.absoluteString.truncatedForS3()
-            }
-            
-            let request = ReportsRequestDTO(
-                reportType: reportsType.rawValue,
-                content: state.reportsContent,
-                imageKeys: imageKeyStrings
-            )
-            
-            self.dispatch(.submitReports(placeId: placeId, request: request))
             
         case .submitReports(let placeId, let request):
             Task {

--- a/Solply/Solply/Presentation/Reports/State/ReportsReducer.swift
+++ b/Solply/Solply/Presentation/Reports/State/ReportsReducer.swift
@@ -31,12 +31,6 @@ enum ReportsReducer {
             state.shouldGoBack = true
             break
             
-        case .submitPresignedUrlRequest:
-            break
-            
-        case .presignedUrlRequestSubmitted:
-            break
-            
         case .submitReports:
             break
             
@@ -47,14 +41,6 @@ enum ReportsReducer {
             // TODO: - 제보 실패했을 때 처리 필요
             print("제보하기에 실패했습니다 error: \(error)")
             state.shouldGoBack = true
-            break
-            
-        case .photoUploadSuccess:
-            print("S3 사진 업로드 성공")
-            break
-            
-        case .photoUploadFailed(let error):
-            print("S3 사진 업로드 실패 error: \(error)")
             break
         }
     }


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 기록하기 API 연동했습니다.
- 사진 업로드하는 과정을 하나의 class에서 관리하도록 수정했어요. 이제 모두가 사진 업로드를 연결할 수 있음~!

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| 귗찮으니 사진 | <img src = "https://github.com/user-attachments/assets/074ff640-3c9d-4a84-be36-c2e6110040b0" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 사용 방법
- 사진을 업로드하는 과정은 이전과 동일하기 때문에 설명하지 않겠습니다! 사용하는 방법만 알아도 댐
- 주석 정성스럽게 달아놨으니 꼼꼼하게 읽어보시면 좋을 거 같아요오

<img width="500" alt="스크린샷 2026-04-12 17 05 26" src="https://github.com/user-attachments/assets/1cc18c77-4392-46cd-9ba7-229fad92b0b6" />


```Swift
// RegisterEffect.swift

 case .startRegister:
     Task {
         let imageKeyStrings = await PhotoUploadManager.shared.upload(imageDatas: state.attachedImageData)
         self.dispatch(.submitRegister(imageKeyStrings: imageKeyStrings))
     }
```
사용자가 사진을 업로드하지 않은 경우에 API를 호출할 때 빈 배열로 보내게 되어있어서, 그거에 맞춰서 업로드할 이미지가 없는 경우에는 error를 던지지 않고 그냥 빈배열을 반환하도록 했어요. 그래서 위와 같이 간단하게 사용하면 됩니닷.

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #492 

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
[[feat/#288] 제보하기 api 연동](https://github.com/SOLPLY/SOLPLY-iOS/pull/304) <- S3에 사진 업로드하는 과정 설명 pr
근데 주석으로 다 달아놔서 굳이 안 봐도 댐

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 기록하기에는 사진이 최대 5장까지 선택이 가능해서, 이거는 다음 이슈에 이어서 하겠습니다.