### PR TITLE
[feat/#498] PlaceComplaintView 모달 연결

### DIFF
--- a/Solply/Solply/Global/DesignSystem/Assets.xcassets/Image-icon/success-icon.imageset/success-icon.svg
+++ b/Solply/Solply/Global/DesignSystem/Assets.xcassets/Image-icon/success-icon.imageset/success-icon.svg
@@ -1,4 +1,4 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="12" cy="12" r="10" fill="#D3DD91"/>
-<path d="M6.80005 11.601L11.2 16.001L16.4 8.80099" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="21.6667" cy="21.6667" r="21.6667" fill="#A3C25B"/>
+<path d="M10.3999 20.802L19.9332 30.3354L31.1999 14.7354" stroke="white" stroke-width="4.33333" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/Solply/Solply/Global/Enum/AlertType.swift
+++ b/Solply/Solply/Global/Enum/AlertType.swift
@@ -15,6 +15,7 @@ enum AlertType {
     case logout
     case withdraw
     case authenticationRequired
+    case complaint
     
     var title: String {
         switch self {
@@ -25,6 +26,7 @@ enum AlertType {
         case .logout: return "로그아웃하시겠습니까?"
         case .withdraw: return "탈퇴하시겠습니까?"
         case .authenticationRequired: return "로그인이 필요한 기능이에요."
+        case .complaint: return "신고가 접수되면 검토 후\n필요한 조치가 이루어져요"
         }
     }
     
@@ -46,6 +48,8 @@ enum AlertType {
             return "탈퇴"
         case .authenticationRequired:
             return "로그인"
+        case .complaint:
+            return "신고하기"
         }
     }
 }

--- a/Solply/Solply/Presentation/Complaint/Component/ComplaintCompleteModal.swift
+++ b/Solply/Solply/Presentation/Complaint/Component/ComplaintCompleteModal.swift
@@ -1,0 +1,57 @@
+//
+//  ComplaintCompleteModal.swift
+//  Solply
+//
+//  Created by sun on 4/16/26.
+//
+
+import SwiftUI
+
+struct ComplaintCompleteModal: View {
+    
+    let confirmAction: () -> Void
+    
+    var body: some View {
+        ZStack(alignment: .center) {
+            Color.coreBlackO40
+                .ignoresSafeArea()
+            
+            VStack(alignment: .center, spacing: 16.adjustedHeight) {
+                
+                Image(.successIcon)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 52.adjustedWidth, height: 52.adjustedHeight)
+                    .padding(.top, 22.adjustedHeight)
+                
+                Text("신고가 접수되었어요")
+                    .applySolplyFont(.body_16_m)
+                    .foregroundStyle(.coreBlack)
+                
+                Text("커뮤니티를 지켜주셔서 감사합니다!\n검토 후 필요한 조치를 진행할게요.")
+                    .applySolplyFont(.body_14_r)
+                    .foregroundStyle(.coreBlack)
+                    .multilineTextAlignment(.center)
+                
+                SolplyMainButton(
+                    title: "확인",
+                    isEnabled: true
+                ) {
+                    confirmAction()
+                }
+                .padding(.top, 16.adjustedHeight)
+            }
+            .padding(.horizontal, 20.adjustedWidth)
+            .padding(.vertical, 24.adjustedHeight)
+            .frame(width: 260.adjustedWidth)
+            .background(.coreWhite)
+            .cornerRadius(12)
+        }
+    }
+}
+
+#Preview {
+    ComplaintCompleteModal(
+        confirmAction: {}
+    )
+}

--- a/Solply/Solply/Presentation/Complaint/Component/ComplaintCompleteModal.swift
+++ b/Solply/Solply/Presentation/Complaint/Component/ComplaintCompleteModal.swift
@@ -9,7 +9,17 @@ import SwiftUI
 
 struct ComplaintCompleteModal: View {
     
-    let confirmAction: () -> Void
+    // MARK: - Properties
+    
+    private let confirmAction: (() -> Void)?
+    
+    // MARK: - Initializer
+    
+    init(confirmAction: (() -> Void)? = nil) {
+        self.confirmAction = confirmAction
+    }
+    
+    // MARK: - Body
     
     var body: some View {
         ZStack(alignment: .center) {
@@ -37,7 +47,7 @@ struct ComplaintCompleteModal: View {
                     title: "확인",
                     isEnabled: true
                 ) {
-                    confirmAction()
+                    confirmAction?()
                 }
                 .padding(.top, 16.adjustedHeight)
             }
@@ -48,10 +58,4 @@ struct ComplaintCompleteModal: View {
             .cornerRadius(12)
         }
     }
-}
-
-#Preview {
-    ComplaintCompleteModal(
-        confirmAction: {}
-    )
 }

--- a/Solply/Solply/Presentation/Complaint/Intent/PlaceComplaintAction.swift
+++ b/Solply/Solply/Presentation/Complaint/Intent/PlaceComplaintAction.swift
@@ -1,0 +1,16 @@
+//
+//  PlaceComplaintAction.swift
+//  Solply
+//
+//  Created by sun on 4/17/26.
+//
+
+import Foundation
+
+enum PlaceComplaintAction {
+    case selectComplaintType(ComplaintType)
+    case updateContent(String)
+    case complaint
+    case complaintSuccess
+    case complaintFailed(error: NetworkError)
+}

--- a/Solply/Solply/Presentation/Complaint/Intent/PlaceComplaintStore.swift
+++ b/Solply/Solply/Presentation/Complaint/Intent/PlaceComplaintStore.swift
@@ -1,0 +1,45 @@
+//
+//  PlaceComplaintStore.swift
+//  Solply
+//
+//  Created by sun on 4/17/26.
+//
+
+import Foundation
+
+@MainActor
+final class PlaceComplaintStore: ObservableObject {
+    @Published private(set) var state = PlaceComplaintState()
+    
+    func dispatch(_ action: PlaceComplaintAction) {
+        PlaceComplaintReducer.reduce(state: &state, action: action)
+        
+        switch action {
+        case .complaint:
+            guard let selectedComplaintType = state.selectedComplaintType else { return }
+            
+            let trimmedContent = state.content
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            
+            if selectedComplaintType == .others && trimmedContent.isEmpty {
+                return
+            }
+            
+            AlertManager.shared.showAlert(
+                alertType: .complaint,
+                onCancel: nil
+            ) { [weak self] in
+                self?.dispatch(.complaintSuccess)
+            }
+            
+        case .complaintSuccess:
+            break
+            
+        case .complaintFailed(let error):
+            print(error)
+            
+        default:
+            break
+        }
+    }
+}

--- a/Solply/Solply/Presentation/Complaint/State/PlaceComplaintReducer.swift
+++ b/Solply/Solply/Presentation/Complaint/State/PlaceComplaintReducer.swift
@@ -1,0 +1,35 @@
+//
+//  PlaceComplaintReducer.swift
+//  Solply
+//
+//  Created by sun on 4/16/26.
+//
+
+import Foundation
+
+enum PlaceComplaintReducer {
+    static func reduce(state: inout PlaceComplaintState, action: PlaceComplaintAction) {
+        switch action {
+        case .selectComplaintType(let complaintType):
+            state.selectedComplaintType = complaintType
+            
+            if complaintType != .others {
+                state.content = ""
+            }
+            
+        case .updateContent(let text):
+            state.content = String(text.prefix(200))
+            
+        case .complaint:
+            break
+            
+        case .complaintSuccess:
+            state.showComplaintCompleteModal = true
+            break
+            
+        case .complaintFailed(let error):
+            print(error)
+            break
+        }
+    }
+}

--- a/Solply/Solply/Presentation/Complaint/State/PlaceComplaintState.swift
+++ b/Solply/Solply/Presentation/Complaint/State/PlaceComplaintState.swift
@@ -1,0 +1,15 @@
+//
+//  PlaceComplaintState.swift
+//  Solply
+//
+//  Created by sun on 4/16/26.
+//
+
+import Foundation
+
+struct PlaceComplaintState {
+    var selectedComplaintType: ComplaintType?
+    var content: String = ""
+    var showComplaintCompleteModal: Bool = false
+    var error: NetworkError?
+}

--- a/Solply/Solply/Presentation/Complaint/View/PlaceComplaintView.swift
+++ b/Solply/Solply/Presentation/Complaint/View/PlaceComplaintView.swift
@@ -12,10 +12,7 @@ struct PlaceComplaintView: View {
     // MARK: - Properties
     
     @EnvironmentObject private var appCoordinator: AppCoordinator
-    
-    @State private var selectedComplaintType: ComplaintType?
-    @State private var content: String = ""
-    @State private var showComplaintCompleteModal: Bool = false
+    @StateObject private var store = PlaceComplaintStore()
     
     // MARK: - Body
     
@@ -23,10 +20,10 @@ struct PlaceComplaintView: View {
         VStack(alignment: .center, spacing: 0) {
             complaintTypeList
             
-            if selectedComplaintType == .others {
+            if store.state.selectedComplaintType == .others {
                 SolplyTextEditor(
                     onTextChanged: { text in
-                        content = text
+                        store.dispatch(.updateContent(text))
                     }
                 )
             }
@@ -47,9 +44,8 @@ struct PlaceComplaintView: View {
         }
         .customAlert()
         .overlay(alignment: .center) {
-            if showComplaintCompleteModal {
+            if store.state.showComplaintCompleteModal {
                 ComplaintCompleteModal {
-                    showComplaintCompleteModal = false
                     appCoordinator.goBack()
                 }
             }
@@ -60,10 +56,10 @@ struct PlaceComplaintView: View {
 extension PlaceComplaintView {
     
     private var isNextEnabled: Bool {
-        guard let selectedComplaintType else { return false }
+        guard let selectedComplaintType = store.state.selectedComplaintType else { return false }
         
         if selectedComplaintType == .others {
-            return !content
+            return !store.state.content
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .isEmpty
         }
@@ -76,10 +72,10 @@ extension PlaceComplaintView {
             ForEach(ComplaintType.allCases, id: \.self) { complaint in
                 SolplySelectRow(
                     title: complaint.title,
-                    isSelected: selectedComplaintType == complaint,
-                    hideSeparator: selectedComplaintType == complaint && complaint == .others
+                    isSelected: store.state.selectedComplaintType == complaint,
+                    hideSeparator: store.state.selectedComplaintType == complaint && complaint == .others
                 ) {
-                    selectedComplaintType = complaint
+                    store.dispatch(.selectComplaintType(complaint))
                 }
             }
         }
@@ -92,18 +88,9 @@ extension PlaceComplaintView {
             title: "다음",
             isEnabled: isNextEnabled
         ) {
-            showAlert()
+            store.dispatch(.complaint)
         }
         .padding(.horizontal, 20.adjustedWidth)
         .padding(.bottom, 16.adjustedHeight)
-    }
-    
-    private func showAlert() {
-        AlertManager.shared.showAlert(
-            alertType: .complaint,
-            onCancel: nil
-        ) {
-            showComplaintCompleteModal = true
-        }
     }
 }

--- a/Solply/Solply/Presentation/Complaint/View/PlaceComplaintView.swift
+++ b/Solply/Solply/Presentation/Complaint/View/PlaceComplaintView.swift
@@ -15,6 +15,7 @@ struct PlaceComplaintView: View {
     
     @State private var selectedComplaintType: ComplaintType?
     @State private var content: String = ""
+    @State private var showComplaintCompleteModal: Bool = false
     
     // MARK: - Body
     
@@ -45,6 +46,14 @@ struct PlaceComplaintView: View {
             hideKeyboard()
         }
         .customAlert()
+        .overlay(alignment: .center) {
+            if showComplaintCompleteModal {
+                ComplaintCompleteModal {
+                    showComplaintCompleteModal = false
+                    appCoordinator.goBack()
+                }
+            }
+        }
     }
 }
 
@@ -94,6 +103,7 @@ extension PlaceComplaintView {
             alertType: .complaint,
             onCancel: nil
         ) {
+            showComplaintCompleteModal = true
         }
     }
 }

--- a/Solply/Solply/Presentation/Complaint/View/PlaceComplaintView.swift
+++ b/Solply/Solply/Presentation/Complaint/View/PlaceComplaintView.swift
@@ -44,6 +44,7 @@ struct PlaceComplaintView: View {
         .onTapGesture {
             hideKeyboard()
         }
+        .customAlert()
     }
 }
 
@@ -82,8 +83,17 @@ extension PlaceComplaintView {
             title: "다음",
             isEnabled: isNextEnabled
         ) {
+            showAlert()
         }
         .padding(.horizontal, 20.adjustedWidth)
         .padding(.bottom, 16.adjustedHeight)
+    }
+    
+    private func showAlert() {
+        AlertManager.shared.showAlert(
+            alertType: .complaint,
+            onCancel: nil
+        ) {
+        }
     }
 }


### PR DESCRIPTION
## 📄 작업 내용
- `success-icon` 변경
- `ComplaintCompleteModal` 구현
- `PlaceComplaintView`에 모달 2개 연결

|    구현 내용    |   iPhone 13 mini   |   iPhone 17 pro   |
| :-------------: | :----------: | :----------: |
| `PlaceComplaintView`<br>모달 | <img src = "https://github.com/user-attachments/assets/84ae5eb4-06b7-437a-bdee-1b9029afee92" width ="250"> | <img src = "https://github.com/user-attachments/assets/1232875a-bb7e-4a7c-9cba-c350ecfd6470" width ="250"> |

## 💻 주요 코드 설명
### 완료 모달 표시
신고하기 완료 모달을 별도 View로 분리했는데요!
이유는 기존의 레이아웃과 달라서 새로 만들었습니듀

```Swift
.overlay(alignment: .center) {
    if showComplaintCompleteModal {
        ComplaintCompleteModal {
            showComplaintCompleteModal = false
            appCoordinator.goBack()
        }
    }
}
```

overlay를 활용하여 화면 위에 ComplaintCompleteModal(두번째 모달)을 띄었는데용
`showComplaintCompleteModal` 상태값을 기준으로 모달 표시 여부를 제어하고,
모달의 확인 버튼을 누르면 모달을 닫고 이전 화면으로 돌아가집니다

## 🔗 연결된 이슈
- Connected: #498

## 👀 기타 더 이야기해볼 점
모달도 뷰니까... UI 표현용 상태를 View가 직접 관리하는 측면에서

- 첫 번째 알럿은 `AlertManager`
- 두 번째 완료 모달은 `overlay` + `@State`

괜찮조??  이상하면 말해주세욥
