### PR TITLE
[feat/#502] 내 솔플리 기록 섹션 추가

### DIFF
--- a/Solply/Solply/Presentation/MyPage/MyPage/Entity/MySolplyRecord.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPage/Entity/MySolplyRecord.swift
@@ -1,0 +1,61 @@
+//
+//  MySolplyRecord.swift
+//  Solply
+//
+//  Created by 김승원 on 4/17/26.
+//
+
+import Foundation
+
+struct MySolplyRecord: Identifiable {
+    let id: Int
+    let placeTagType: MainTagType
+    let placeId: Int
+    let placeName: String
+    let PhotosUrls: [String]
+    let recordText: String
+    let visitTime: String
+}
+
+extension MySolplyRecord {
+    static var mock: [MySolplyRecord] {
+        return [
+            MySolplyRecord(
+                id: 1,
+                placeTagType: .book,
+                placeId: 1,
+                placeName: "임시장소1",
+                PhotosUrls: [
+                    "https://i.pinimg.com/1200x/23/ce/ea/23ceead7c9d0d5db016b404faa3bbd87.jpg",
+                    "https://i.pinimg.com/1200x/23/ce/ea/23ceead7c9d0d5db016b404faa3bbd87.jpg",
+                    "https://i.pinimg.com/1200x/23/ce/ea/23ceead7c9d0d5db016b404faa3bbd87.jpg",
+                    "https://i.pinimg.com/1200x/23/ce/ea/23ceead7c9d0d5db016b404faa3bbd87.jpg",
+                    "https://i.pinimg.com/1200x/23/ce/ea/23ceead7c9d0d5db016b404faa3bbd87.jpg"
+                ],
+                recordText: "주말 오후에 방문했는데 사람이 많지 않아서 좋았어요. 창가 자리에서 노트북 작업하기 딱 좋았습니다. 음료도 맛있고 분위기도 차분해서 집중이 잘 됐어요.",
+                visitTime: "2026.02.19 오후 방문"
+            ),
+            MySolplyRecord(
+                id: 2,
+                placeTagType: .food,
+                placeId: 2,
+                placeName: "임시장소2",
+                PhotosUrls: [],
+                recordText: "주말 오후에 방문했는데 사람이 많지 않아서 좋았어요. 창가 자리에서 노트북 작업하기 딱 좋았습니다. 음료도 맛있고 분위기도 차분해서 집중이 잘 됐어요.",
+                visitTime: "2026.02.19 오후 방문"
+            ),
+            MySolplyRecord(
+                id: 3,
+                placeTagType: .walk,
+                placeId: 3,
+                placeName: "임시장소3",
+                PhotosUrls: [
+                    "https://i.pinimg.com/1200x/23/ce/ea/23ceead7c9d0d5db016b404faa3bbd87.jpg",
+                    "https://i.pinimg.com/1200x/23/ce/ea/23ceead7c9d0d5db016b404faa3bbd87.jpg"
+                ],
+                recordText: "주말 오후에 방문했는데 사람이 많지 않아서 좋았어요. 창가 자리에서 노트북 작업하기 딱 좋았습니다. 음료도 맛있고 분위기도 차분해서 집중이 잘 됐어요.",
+                visitTime: "2026.02.19 오후 방문"
+            )
+        ]
+    }
+}

--- a/Solply/Solply/Presentation/MyPage/MyPage/View/MyPageView.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPage/View/MyPageView.swift
@@ -15,6 +15,9 @@ struct MyPageView: View {
     @EnvironmentObject private var appCoordinator: AppCoordinator
     @StateObject private var store = MyPageStore()
     
+    // 임시
+    private var mySolplyRecords: [MySolplyRecord]? = MySolplyRecord.mock
+    
     // MARK: - Body
     
     var body: some View {
@@ -24,27 +27,29 @@ struct MyPageView: View {
             
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {
-                    header
+                    userProfileHeader
                     
-                    MyPageSection(
-                        type: .registeredPlaces,
-                        items: appState.userInformation?.myPlacePreviews ?? [],
-                        onSeeAllTapped: {
-                            guard let userId = appState.userInformation?.userId else { return }
-                            
-                            appCoordinator.navigate(to: .registeredPlaces(userId: userId))
-                        }
-                    )
-                    .padding(.top, 44.adjustedHeight)
+//                    MyPageSection(
+//                        type: .record,
+//                        items: [],
+//                        onSeeAllTapped: {
+//                            // TODO: - 나의 솔플 기록 전체보기 연결
+//                        }
+//                    )
+                    mySolplyRecordSection
+                        .padding(.top, 44.adjustedHeight)
 
-                    MyPageSection(
-                        type: .record,
-                        items: [],
-                        onSeeAllTapped: {
-                            print("내 솔플리 기록 전체보기")
-                        }
-                    )
-                    .padding(.top, 16.adjustedHeight)
+//                    MyPageSection(
+//                        type: .registeredPlaces,
+//                        items: appState.userInformation?.myPlacePreviews ?? [],
+//                        onSeeAllTapped: {
+//                            guard let userId = appState.userInformation?.userId else { return }
+//                            
+//                            appCoordinator.navigate(to: .registeredPlaces(userId: userId))
+//                        }
+//                    )
+                    myRegisteredPlacesSection
+                        .padding(.top, 16.adjustedHeight)
                     
                     MyPageSettings(
                         loginProvider: store.state.loginInformation,
@@ -90,7 +95,7 @@ struct MyPageView: View {
 // MARK: - Header
 
 private extension MyPageView {
-    var header: some View {
+    var userProfileHeader: some View {
         VStack(alignment: .center, spacing: 15.adjustedHeight) {
             ProfileImage(profileImageUrl: appState.userInformation?.profileImageUrl)
             
@@ -121,5 +126,152 @@ private extension MyPageView {
             .buttonStyle(.plain)
         }
         .frame(maxWidth: .infinity, alignment: .center)
+    }
+    
+    var mySolplyRecordSection: some View {
+        VStack(alignment: .center, spacing: 16.adjustedHeight) {
+            sectionHeader(
+                title: "내 솔플리 기록",
+                // TODO: - API 연결 후 버튼 활성화 수정 필요
+                isButtonEnabled: true) {
+                    // TODO: - 내 솔플리 기록 전체보기 연결 필요
+                    
+                }
+            
+            mySolplyRecordList()
+        }
+        .padding(.vertical, 16.adjustedHeight)
+        .padding(.horizontal, 20.adjustedWidth)
+        .background(.coreWhite)
+    }
+    
+    var myRegisteredPlacesSection: some View {
+        VStack(alignment: .center, spacing: 16.adjustedHeight) {
+            sectionHeader(
+                title: "내가 등록한 장소",
+                isButtonEnabled: !(appState.userInformation?.myPlacePreviews.isEmpty ?? true)
+            ) {
+                guard let userId = appState.userInformation?.userId else { return }
+                
+                appCoordinator.navigate(to: .registeredPlaces(userId: userId))
+            }
+            .padding(.horizontal, 20.adjustedWidth)
+            
+            myRegisteredPlacesList()
+        }
+        .padding(.vertical, 16.adjustedHeight)
+        .background(.coreWhite)
+    }
+    
+    @ViewBuilder
+    func mySolplyRecordList() -> some View {
+        // TODO: - API 연결 후 수정 필요
+        if let mySolplyRecords = mySolplyRecords, !mySolplyRecords.isEmpty {
+            VStack(alignment: .center, spacing: 0) {
+                ForEach(Array(mySolplyRecords.enumerated()), id: \.offset) { index, mySolplyRecord in
+                    mySolplyRecordRow(mySolplyRecord, showsDivider: mySolplyRecords.count - 1 != index)
+                }
+            }
+        } else {
+            emptyView(title: "등록한 기록이 없어요")
+        }
+    }
+    
+    func mySolplyRecordRow(_ mySolplyRecord: MySolplyRecord, showsDivider: Bool) -> some  View {
+        VStack(alignment: .center, spacing: 0) {
+            HStack(alignment: .top, spacing: 12.adjustedWidth) {
+                ThumbnailImage(
+                    mySolplyRecord.PhotosUrls.first,
+                    width: 72.adjusted,
+                    height: 72.adjusted,
+                    radius: 12
+                )
+                
+                VStack(alignment: .leading, spacing: 8.adjustedHeight) {
+                    Text(mySolplyRecord.placeName)
+                        .applySolplyFont(.title_15_m)
+                        .foregroundStyle(.coreBlack)
+                    
+                    Text(mySolplyRecord.recordText)
+                        .applySolplyFont(.body_14_r)
+                        .foregroundStyle(.gray900)
+                        .lineLimit(2)
+                }
+                .frame(width: 251.adjustedWidth, alignment: .center)
+            }
+            
+            if showsDivider {
+                Rectangle()
+                    .frame(height: 1.adjustedHeight)
+                    .frame(maxWidth: .infinity)
+                    .foregroundStyle(.gray200)
+                    .padding(.vertical, 16.adjustedHeight)
+            }
+        }
+    }
+    
+    @ViewBuilder
+    func myRegisteredPlacesList() -> some View {
+        if let myPlacePreviews = appState.userInformation?.myPlacePreviews, !myPlacePreviews.isEmpty {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(alignment: .top, spacing: 16.adjustedWidth) {
+                    ForEach(myPlacePreviews, id: \.id) { item in
+                        PlaceCard(
+                            isSaved: item.isBookmarked,
+                            thumbnailUrl: item.thumbnail,
+                            placeName: item.name,
+                            placeCategory: item.mainTag,
+                            isSelected: false,
+                            size: 145.adjusted
+                        )
+                    }
+                }
+            }
+            .contentMargins(.horizontal, 20.adjustedWidth)
+        } else {
+            emptyView(title: "등록한 장소가 없어요")
+        }
+    }
+    
+    func sectionHeader(
+        title: String,
+        isButtonEnabled: Bool,
+        action: (() -> Void)?
+    ) -> some View {
+        HStack(alignment: .center, spacing: 0) {
+            Text(title)
+                .applySolplyFont(.body_16_m)
+                .foregroundColor(.coreBlack)
+            
+            Spacer()
+            
+            if isButtonEnabled {
+                Button {
+                    action?()
+                } label: {
+                    HStack(spacing: 0) {
+                        Text("전체 보기")
+                            .applySolplyFont(.body_14_r)
+                            .foregroundColor(.gray600)
+                        
+                        Image(.arrowRightIconThin)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 24.adjusted, height: 24.adjusted)
+                            .foregroundColor(.gray600)
+                    }
+                    .padding(.leading, 12.adjustedWidth)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+    
+    func emptyView(title: String) -> some View {
+        Text(title)
+            .applySolplyFont(.body_16_r)
+            .foregroundColor(.gray400)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .frame(height: 40.adjustedHeight)
     }
 }


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 내 솔플리 기록 섹션 추가했습니다

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| UI | <img src = "https://github.com/user-attachments/assets/37b498af-2175-4c5a-b7d5-1095443c2037" width ="250"> | <img src = "https://github.com/user-attachments/assets/4776f607-5f5e-4033-acfb-97168f5722af" width ="250"> |


## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #502 

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 컴포넌트로 뺼까 했는데,, 재사용이 필요 없어서(내가 등록한 장소와 사용하는 Entity와 컴포가 다름) MyPageView의 서브뷰로 작성했어요.
- 그러면서 뷰빌더를 사용했는데, 궁금한 점이 있다면 남겨주세요오
- 또한 MyPageSectionType과 같이 이제 사용하지 않아도 되는 것들이 남아있는데, 다음 이슈에서 지우겟습니다!! @dudwntjs 