### PR TITLE
[feat/#509] 내 솔플리 기록 API 연동

### DIFF
--- a/Solply/Solply/Global/Component/SolplyDatePicker.swift
+++ b/Solply/Solply/Global/Component/SolplyDatePicker.swift
@@ -51,6 +51,7 @@ struct SolplyDatePicker: View {
             minHeight: 52.adjustedHeight,
             alignment: .leading
         )
+        .background(.coreWhite)
         .addBorder(
             .roundedRectangle(cornerRadius: 20.adjustedWidth),
             borderColor: .gray300,

--- a/Solply/Solply/Global/Enum/CustomLoadingType.swift
+++ b/Solply/Solply/Global/Enum/CustomLoadingType.swift
@@ -18,4 +18,5 @@ enum CustomLoadingType {
     case courseDetailLoading
     case archiveFolderLoading
     case recordListLoading
+    case mySolplyRecordsLoading
 }

--- a/Solply/Solply/Global/Modifier/CustomLoadingModifier.swift
+++ b/Solply/Solply/Global/Modifier/CustomLoadingModifier.swift
@@ -424,6 +424,53 @@ extension View {
                     }
                 )
             )
+            
+        case .mySolplyRecordsLoading:
+            self.modifier(
+                CustomLoadingModifier(
+                    isLoading: isLoading,
+                    loadingView: {
+                        VStack(alignment: .center, spacing: 0) {
+                            ForEach(0..<2) { index in
+                                VStack(alignment: .leading, spacing: 16.adjustedHeight) {
+                                    SolplySkeletonView(font: .body_14_r, width: 120.adjustedWidth)
+                                        .padding(.leading, 16.adjustedWidth)
+                                    
+                                    HStack(alignment: .center, spacing: 8.adjustedWidth) {
+                                        ForEach(0..<5) { _ in
+                                            SolplySkeletonView(width: 72.adjusted, height: 72.adjusted, cornerRadius: 12)
+                                        }
+                                    }
+                                    .padding(.leading, 16.adjustedWidth)
+                                    .frame(width: 375.adjustedWidth, alignment: .leading)
+                                    .clipped()
+                                    
+                                    VStack(alignment: .leading, spacing: 0) {
+                                        SolplySkeletonView(font: .body_14_r, width: 343.adjustedWidth, cornerRadius: 4)
+                                        SolplySkeletonView(font: .body_14_r, width: 343.adjustedWidth, cornerRadius: 4)
+                                        SolplySkeletonView(font: .body_14_r, width: 250.adjustedWidth, cornerRadius: 4)
+                                    }
+                                    .padding(.leading, 16.adjustedWidth)
+                                    
+                                    SolplySkeletonView(font: .body_14_r, width: 120.adjustedWidth, cornerRadius: 4)
+                                        .padding(.leading, 16.adjustedWidth)
+                                }
+                                .padding(.vertical, 20.adjustedHeight)
+                                .overlay(alignment: .bottom) {
+                                    if index != 1 {
+                                        Rectangle()
+                                            .frame(maxWidth: .infinity)
+                                            .frame(height: 1)
+                                            .padding(.horizontal, 16.adjustedWidth)
+                                            .foregroundStyle(.gray200)
+                                    }
+                                }
+
+                            }
+                        }
+                    }
+                )
+            )
         }
     }
 }

--- a/Solply/Solply/Network/API/PlaceAPI.swift
+++ b/Solply/Solply/Network/API/PlaceAPI.swift
@@ -55,4 +55,7 @@ protocol PlaceAPI {
     
     /// 장소 리뷰(기록) 리스트 조회
     func fetchPlaceRecordList(placeId: Int) async throws -> BaseResponseBody<PlaceRecordListResponseDTO>
+    
+    /// 내 리뷰(기록) 리스트 조회
+    func fetchMySolplysRecords() async throws -> BaseResponseBody<MySolplyRecordsResponseDTO>
 }

--- a/Solply/Solply/Network/API/PlaceAPI.swift
+++ b/Solply/Solply/Network/API/PlaceAPI.swift
@@ -58,4 +58,7 @@ protocol PlaceAPI {
     
     /// 내 리뷰(기록) 리스트 조회
     func fetchMySolplysRecords() async throws -> BaseResponseBody<MySolplyRecordsResponseDTO>
+    
+    /// 내 장소 리뷰(기록) 삭제
+    func removeMySolplyRecord(reviewId: Int) async throws -> BaseResponseBody<EmptyResponseDTO>
 }

--- a/Solply/Solply/Network/API/PlaceAPI.swift
+++ b/Solply/Solply/Network/API/PlaceAPI.swift
@@ -57,7 +57,7 @@ protocol PlaceAPI {
     func fetchPlaceRecordList(placeId: Int) async throws -> BaseResponseBody<PlaceRecordListResponseDTO>
     
     /// 내 리뷰(기록) 리스트 조회
-    func fetchMySolplysRecords() async throws -> BaseResponseBody<MySolplyRecordsResponseDTO>
+    func fetchMySolplyRecords() async throws -> BaseResponseBody<MySolplyRecordsResponseDTO>
     
     /// 내 장소 리뷰(기록) 삭제
     func removeMySolplyRecord(reviewId: Int) async throws -> BaseResponseBody<EmptyResponseDTO>

--- a/Solply/Solply/Network/DTO/Place/ResponseDTO/MySolplyRecordsResponseDTO.swift
+++ b/Solply/Solply/Network/DTO/Place/ResponseDTO/MySolplyRecordsResponseDTO.swift
@@ -15,8 +15,9 @@ struct MySolplyRecordsResponseDTO: ResponseModelType {
 struct MySolplyRecordDTO: ResponseModelType {
     let reviewId: Int
     let placeId: Int
+    let placeName: String
     let content: String
     let visitedAt: String
-    let visitTimeSlot: String
+    let visitTimeSlot: VisitTime
     let imageUrls: [String]
 }

--- a/Solply/Solply/Network/DTO/Place/ResponseDTO/MySolplyRecordsResponseDTO.swift
+++ b/Solply/Solply/Network/DTO/Place/ResponseDTO/MySolplyRecordsResponseDTO.swift
@@ -1,0 +1,22 @@
+//
+//  MySolplyRecordsResponseDTO.swift
+//  Solply
+//
+//  Created by 김승원 on 5/7/26.
+//
+
+import Foundation
+
+struct MySolplyRecordsResponseDTO: ResponseModelType {
+    let reviewCount: Int
+    let reviews: [MySolplyRecordDTO]
+}
+
+struct MySolplyRecordDTO: ResponseModelType {
+    let reviewId: Int
+    let placeId: Int
+    let content: String
+    let visitedAt: String
+    let visitTimeSlot: String
+    let imageUrls: [String]
+}

--- a/Solply/Solply/Network/DTO/Place/ResponseDTO/MySolplyRecordsResponseDTO.swift
+++ b/Solply/Solply/Network/DTO/Place/ResponseDTO/MySolplyRecordsResponseDTO.swift
@@ -16,6 +16,7 @@ struct MySolplyRecordDTO: ResponseModelType {
     let reviewId: Int
     let placeId: Int
     let placeName: String
+    let mainTag: String
     let content: String
     let visitedAt: String
     let visitTimeSlot: VisitTime

--- a/Solply/Solply/Network/DTO/Recommend/ResponseDTO/AICourseRecommendResponseDTO.swift
+++ b/Solply/Solply/Network/DTO/Recommend/ResponseDTO/AICourseRecommendResponseDTO.swift
@@ -16,6 +16,7 @@ struct AIRecommendedCourse: ResponseModelType {
     let courseName: String
     let thumbnailImageUrl: String
     let courseTag: String
+    let townId: Int
     let townName: String
     let reason: String
     let placeMainTags: [String]

--- a/Solply/Solply/Network/DTO/Recommend/ResponseDTO/AIPlaceRecommendResponseDTO.swift
+++ b/Solply/Solply/Network/DTO/Recommend/ResponseDTO/AIPlaceRecommendResponseDTO.swift
@@ -17,6 +17,7 @@ struct AIRecommendedPlace: ResponseModelType {
     let thumbnailImageUrl: String
     let mainTag: String
     let optionTags: [String]
+    let townId: Int
     let townName: String
     let reason: String
 }

--- a/Solply/Solply/Network/DTO/User/ResponseDTO/UserInformationResponseDTO.swift
+++ b/Solply/Solply/Network/DTO/User/ResponseDTO/UserInformationResponseDTO.swift
@@ -14,6 +14,7 @@ struct UserInformationResponseDTO: ResponseModelType {
     let selectedTown: SelectedTownDTO
     let persona: String
     let myPlacePreviews: [MyPlacePreviewDTO]
+    let myReviewPreview: ReviewPreviewDTO
 }
 
 struct SelectedTownDTO: ResponseModelType {
@@ -27,4 +28,16 @@ struct MyPlacePreviewDTO: ResponseModelType {
     let thumbnailImageUrl: String?
     let mainTag: MainTagType
     let isBookmarked: Bool
+}
+
+struct ReviewPreviewDTO: ResponseModelType {
+    let reviews: [ReviewDTO]
+    let hasMoreReviews: Bool
+}
+
+struct ReviewDTO: ResponseModelType {
+    let reviewId: Int
+    let placeName: String
+    let previewImageUrl: String?
+    let content: String
 }

--- a/Solply/Solply/Network/MockService/MockRecommendService.swift
+++ b/Solply/Solply/Network/MockService/MockRecommendService.swift
@@ -90,6 +90,7 @@ extension MockRecommendService: RecommendAPI {
                     thumbnailImageUrl: "https://d2ga1f2858oj5h.cloudfront.net/dev/uploads/places/25/place_025_image_1.jpg",
                     mainTag: "CAFE",
                     optionTags: ["WORK", "READING"],
+                    townId: 1,
                     townName: "망원",
                     reason: "a;dslkfja;sldkjf;alksdjf;lakdsjf;lkj"
                 )
@@ -110,6 +111,7 @@ extension MockRecommendService: RecommendAPI {
                     courseName: "임시 코스 1",
                     thumbnailImageUrl: "https://d2ga1f2858oj5h.cloudfront.net/dev/uploads/places/25/place_025_image_1.jpg",
                     courseTag: "FOOD",
+                    townId: 1,
                     townName: "망원",
                     reason: "안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요",
                     placeMainTags: ["CAFE", "SHOPPING"]

--- a/Solply/Solply/Network/Service/PlaceService.swift
+++ b/Solply/Solply/Network/Service/PlaceService.swift
@@ -87,7 +87,7 @@ extension PlaceService: PlaceAPI {
         return try await self.request(with: .fetchPlaceRecordList(placeId: placeId))
     }
     
-    func fetchMySolplysRecords() async throws -> BaseResponseBody<MySolplyRecordsResponseDTO> {
+    func fetchMySolplyRecords() async throws -> BaseResponseBody<MySolplyRecordsResponseDTO> {
         return try await self.request(with: .fetchMySolplyRecords)
     }
     

--- a/Solply/Solply/Network/Service/PlaceService.swift
+++ b/Solply/Solply/Network/Service/PlaceService.swift
@@ -90,4 +90,8 @@ extension PlaceService: PlaceAPI {
     func fetchMySolplysRecords() async throws -> BaseResponseBody<MySolplyRecordsResponseDTO> {
         return try await self.request(with: .fetchMySolplyRecords)
     }
+    
+    func removeMySolplyRecord(reviewId: Int) async throws -> BaseResponseBody<EmptyResponseDTO> {
+        return try await self.request(with: .removeMySolplyRecord(reviewId: reviewId))
+    }
 }

--- a/Solply/Solply/Network/Service/PlaceService.swift
+++ b/Solply/Solply/Network/Service/PlaceService.swift
@@ -86,4 +86,8 @@ extension PlaceService: PlaceAPI {
     func fetchPlaceRecordList(placeId: Int) async throws -> BaseResponseBody<PlaceRecordListResponseDTO> {
         return try await self.request(with: .fetchPlaceRecordList(placeId: placeId))
     }
+    
+    func fetchMySolplysRecords() async throws -> BaseResponseBody<MySolplyRecordsResponseDTO> {
+        return try await self.request(with: .fetchMySolplyRecords)
+    }
 }

--- a/Solply/Solply/Network/TargetType/PlaceTargetType.swift
+++ b/Solply/Solply/Network/TargetType/PlaceTargetType.swift
@@ -28,6 +28,7 @@ enum PlaceTargetType {
     case submitPlaceRecordWrite(request: PlaceRecordWriteRequestDTO)
     case fetchPlaceRecordList(placeId: Int)
     case fetchMySolplyRecords
+    case removeMySolplyRecord(reviewId: Int)
 }
 
 extension PlaceTargetType: BaseTargetType {
@@ -61,6 +62,8 @@ extension PlaceTargetType: BaseTargetType {
             return "/places/reviews/\(placeId)/reviews"
         case .fetchMySolplyRecords:
             return "/places/reviews/me"
+        case .removeMySolplyRecord(let reviewId):
+            return "/places/reviews/\(reviewId)"
         }
     }
     
@@ -78,6 +81,7 @@ extension PlaceTargetType: BaseTargetType {
         case .submitPlaceRecordWrite: return .post
         case .fetchPlaceRecordList: return .get
         case .fetchMySolplyRecords: return .get
+        case .removeMySolplyRecord: return .delete
         }
     }
     
@@ -136,6 +140,8 @@ extension PlaceTargetType: BaseTargetType {
         case .fetchPlaceRecordList:
             return .requestPlain
         case .fetchMySolplyRecords:
+            return .requestPlain
+        case .removeMySolplyRecord:
             return .requestPlain
         }
     }

--- a/Solply/Solply/Network/TargetType/PlaceTargetType.swift
+++ b/Solply/Solply/Network/TargetType/PlaceTargetType.swift
@@ -60,7 +60,7 @@ extension PlaceTargetType: BaseTargetType {
         case .fetchPlaceRecordList(let placeId):
             return "/places/reviews/\(placeId)/reviews"
         case .fetchMySolplyRecords:
-            return "/places/revies/me"
+            return "/places/reviews/me"
         }
     }
     

--- a/Solply/Solply/Network/TargetType/PlaceTargetType.swift
+++ b/Solply/Solply/Network/TargetType/PlaceTargetType.swift
@@ -27,6 +27,7 @@ enum PlaceTargetType {
     case submitRegister(request: RegisterRequestDTO)
     case submitPlaceRecordWrite(request: PlaceRecordWriteRequestDTO)
     case fetchPlaceRecordList(placeId: Int)
+    case fetchMySolplyRecords
 }
 
 extension PlaceTargetType: BaseTargetType {
@@ -58,6 +59,8 @@ extension PlaceTargetType: BaseTargetType {
             return "/places/reviews"
         case .fetchPlaceRecordList(let placeId):
             return "/places/reviews/\(placeId)/reviews"
+        case .fetchMySolplyRecords:
+            return "/places/revies/me"
         }
     }
     
@@ -74,6 +77,7 @@ extension PlaceTargetType: BaseTargetType {
         case .submitRegister: return .post
         case .submitPlaceRecordWrite: return .post
         case .fetchPlaceRecordList: return .get
+        case .fetchMySolplyRecords: return .get
         }
     }
     
@@ -130,6 +134,8 @@ extension PlaceTargetType: BaseTargetType {
         case .submitPlaceRecordWrite(let request):
             return .requestJSONEncodable(request)
         case .fetchPlaceRecordList:
+            return .requestPlain
+        case .fetchMySolplyRecords:
             return .requestPlain
         }
     }

--- a/Solply/Solply/Presentation/AIRecommend/AIRecommendPrompt/Effect/AIRecommendPromptEffect.swift
+++ b/Solply/Solply/Presentation/AIRecommend/AIRecommendPrompt/Effect/AIRecommendPromptEffect.swift
@@ -34,6 +34,7 @@ extension AIRecommendPromptEffect {
                         id: place.placeId,
                         mainTag: MainTagType(rawValue: place.mainTag) ?? .book,
                         placeName: place.placeName,
+                        townId: place.townId,
                         townName: place.townName,
                         tipText: place.reason,
                         filters: place.optionTags,
@@ -59,7 +60,6 @@ extension AIRecommendPromptEffect {
                 return .submitAICourseRecommendFailed(error: .responseError)
             }
             
-            // TODO: - 데이터 매핑 필요
             let result = data.courses.map { course in
                 let courseCounts = Dictionary(grouping: course.placeMainTags, by: { $0 })
                     .map { AIRecommendCourseCountItem(mainTag: $0.key, count: $0.value.count) }
@@ -68,6 +68,7 @@ extension AIRecommendPromptEffect {
                     id: course.courseId,
                     courseTagType: CourseTagType(rawValue: course.courseTag) ?? .daily,
                     courseName: course.courseName,
+                    townId: course.townId,
                     townName: course.townName,
                     tipText: course.reason,
                     courseCounts: courseCounts,

--- a/Solply/Solply/Presentation/AIRecommend/AIRecommendResult/Entity/AIRecommendCard.swift
+++ b/Solply/Solply/Presentation/AIRecommend/AIRecommendResult/Entity/AIRecommendCard.swift
@@ -25,6 +25,7 @@ struct AIRecommendPlaceCardItem: Equatable, Hashable {
     let id: Int
     let mainTag: MainTagType
     let placeName: String
+    let townId: Int
     let townName: String
     let tipText: String
     let filters: [String]
@@ -40,53 +41,9 @@ struct AIRecommendCourseCardItem: Equatable, Hashable {
     let id: Int
     let courseTagType: CourseTagType
     let courseName: String
+    let townId: Int
     let townName: String
     let tipText: String
     let courseCounts: [AIRecommendCourseCountItem]
     let thumbnailImageUrl: String?
-}
-
-// TODO: - API 연결하면 지울게욥!!
-
-extension AIRecommendCard {
-    static let mockData: [AIRecommendCard] = [
-        .place(
-            AIRecommendPlaceCardItem(
-                id: 1,
-                mainTag: .cafe,
-                placeName: "카페",
-                townName: "포항",
-                tipText: "조용한 분위기에서 혼자 작업하기 좋아요",
-                filters: ["조용함", "콘센트", "와이파이"],
-                thumbnailImageUrl: nil
-            )
-        ),
-        .course(
-            AIRecommendCourseCardItem(
-                id: 2,
-                courseTagType: .healing,
-                courseName: "힐링이다",
-                townName: "포항항",
-                tipText: "산책하고 커피 마시기 좋은 코스예요",
-                courseCounts: [
-                    AIRecommendCourseCountItem(mainTag: "카페", count: 2),
-                    AIRecommendCourseCountItem(mainTag: "산책", count: 1),
-                    AIRecommendCourseCountItem(mainTag: "음식", count: 1),
-                    AIRecommendCourseCountItem(mainTag: "서점/책방", count: 1)
-                ],
-                thumbnailImageUrl: nil
-            )
-        ),
-        .place(
-            AIRecommendPlaceCardItem(
-                id: 3,
-                mainTag: .food,
-                placeName: "맛도리",
-                townName: "포항항항",
-                tipText: "혼밥하기 편하고 분위기가 아늑해요",
-                filters: ["혼밥", "브런치", "분위기"],
-                thumbnailImageUrl: nil
-            )
-        )
-    ]
 }

--- a/Solply/Solply/Presentation/AIRecommend/AIRecommendResult/View/AIRecommendResultView.swift
+++ b/Solply/Solply/Presentation/AIRecommend/AIRecommendResult/View/AIRecommendResultView.swift
@@ -83,7 +83,8 @@ private extension AIRecommendResultView {
                         thumbnailImageUrl: item.thumbnailImageUrl
                     )
                     .onTapGesture {
-                        // TODO: 장소 카드 탭 시 장소 상세
+                        // TODO: 장소 카드 탭 시 장소 상세 (townId 수정 필요)
+                        appCoordinator.navigate(to: .placeDetail(townId: 1, placeId: item.id, fromSearch: false))
                     }
 
                 case .course(let item):
@@ -96,7 +97,8 @@ private extension AIRecommendResultView {
                         thumbnailImageUrl: item.thumbnailImageUrl
                     )
                     .onTapGesture {
-                        // TODO: 코스 카드 탭 시 코스 상세
+                        // TODO: 코스 카드 탭 시 코스 상세 (townId 수정 필요)
+                        appCoordinator.navigate(to: .courseDetail(townId: 1, courseId: item.id, fromArchive: false))
                     }
                 }
             }

--- a/Solply/Solply/Presentation/AIRecommend/AIRecommendResult/View/AIRecommendResultView.swift
+++ b/Solply/Solply/Presentation/AIRecommend/AIRecommendResult/View/AIRecommendResultView.swift
@@ -83,8 +83,7 @@ private extension AIRecommendResultView {
                         thumbnailImageUrl: item.thumbnailImageUrl
                     )
                     .onTapGesture {
-                        // TODO: 장소 카드 탭 시 장소 상세 (townId 수정 필요)
-                        appCoordinator.navigate(to: .placeDetail(townId: 1, placeId: item.id, fromSearch: false))
+                        appCoordinator.navigate(to: .placeDetail(townId: item.townId, placeId: item.id, fromSearch: true))
                     }
 
                 case .course(let item):
@@ -97,8 +96,7 @@ private extension AIRecommendResultView {
                         thumbnailImageUrl: item.thumbnailImageUrl
                     )
                     .onTapGesture {
-                        // TODO: 코스 카드 탭 시 코스 상세 (townId 수정 필요)
-                        appCoordinator.navigate(to: .courseDetail(townId: 1, courseId: item.id, fromArchive: false))
+                        appCoordinator.navigate(to: .courseDetail(townId: item.townId, courseId: item.id, fromArchive: false))
                     }
                 }
             }

--- a/Solply/Solply/Presentation/MyPage/MyPage/Entity/MySolplyRecord.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPage/Entity/MySolplyRecord.swift
@@ -22,13 +22,12 @@ extension MySolplyRecord {
         self.id = dto.reviewId
         self.placeId = dto.placeId
         self.placeName = dto.placeName
-        self.placeTagType = .book // TODO: - 서버에서 안 내려줌
+        self.placeTagType = MainTagType(rawValue: dto.mainTag) ?? .book
         self.PhotosUrls = dto.imageUrls
         self.recordText = dto.content
         self.visitTime = "\(dto.visitedAt.replacingOccurrences(of: "-", with: ".")) \(dto.visitTimeSlot.title) 방문"
     }
 }
-
 
 extension MySolplyRecord {
     static var mock: [MySolplyRecord] {

--- a/Solply/Solply/Presentation/MyPage/MyPage/Entity/MySolplyRecord.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPage/Entity/MySolplyRecord.swift
@@ -18,6 +18,19 @@ struct MySolplyRecord: Identifiable {
 }
 
 extension MySolplyRecord {
+    init(dto: MySolplyRecordDTO) {
+        self.id = dto.reviewId
+        self.placeId = dto.placeId
+        self.placeName = dto.placeName
+        self.placeTagType = .book // TODO: - 서버에서 안 내려줌
+        self.PhotosUrls = dto.imageUrls
+        self.recordText = dto.content
+        self.visitTime = "\(dto.visitedAt.replacingOccurrences(of: "-", with: ".")) \(dto.visitTimeSlot.title) 방문"
+    }
+}
+
+
+extension MySolplyRecord {
     static var mock: [MySolplyRecord] {
         return [
             MySolplyRecord(

--- a/Solply/Solply/Presentation/MyPage/MyPage/Entity/MySolplyRecordPreview.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPage/Entity/MySolplyRecordPreview.swift
@@ -1,0 +1,24 @@
+//
+//  MySolplyRecordPreview.swift
+//  Solply
+//
+//  Created by 김승원 on 5/11/26.
+//
+
+import Foundation
+
+struct MySolplyRecordPreview: Hashable {
+    let id: Int
+    let placeName: String
+    let previewImageUrl: String?
+    let content: String
+}
+
+extension MySolplyRecordPreview {
+    init(dto: ReviewDTO) {
+        self.id = dto.reviewId
+        self.placeName = dto.placeName
+        self.previewImageUrl = dto.previewImageUrl
+        self.content = dto.content
+    }
+}

--- a/Solply/Solply/Presentation/MyPage/MyPage/View/MyPageView.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPage/View/MyPageView.swift
@@ -49,7 +49,7 @@ struct MyPageView: View {
                     )
                     .padding(.top, 16.adjustedHeight)
                 }
-                .padding(.bottom, 112.adjustedHeight)
+                .padding(.bottom, 120.adjustedHeight)
             }
         }
         .onChange(of: store.state.shouldChangeRoot) { _, newValue in

--- a/Solply/Solply/Presentation/MyPage/MyPage/View/MyPageView.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPage/View/MyPageView.swift
@@ -15,9 +15,6 @@ struct MyPageView: View {
     @EnvironmentObject private var appCoordinator: AppCoordinator
     @StateObject private var store = MyPageStore()
     
-    // 임시
-    private var mySolplyRecords: [MySolplyRecord]? = MySolplyRecord.mock
-    
     // MARK: - Body
     
     var body: some View {
@@ -116,8 +113,7 @@ private extension MyPageView {
         VStack(alignment: .center, spacing: 16.adjustedHeight) {
             sectionHeader(
                 title: "내 솔플리 기록",
-                // TODO: - API 연결 후 버튼 활성화 수정 필요
-                isButtonEnabled: true) {
+                isButtonEnabled: appState.userInformation?.hasMoreReviews ?? false) {
                     appCoordinator.navigate(to: .mySolplyRecords)
                     
                 }
@@ -148,12 +144,11 @@ private extension MyPageView {
     }
     
     func mySolplyRecordList() -> some View {
-        // TODO: - API 연결 후 수정 필요
         Group {
-            if let mySolplyRecords = mySolplyRecords, !mySolplyRecords.isEmpty {
+            if let mySolplyRecordPreviews = appState.userInformation?.mySolplyRecordPreviews, !mySolplyRecordPreviews.isEmpty {
                 VStack(alignment: .center, spacing: 0) {
-                    ForEach(Array(mySolplyRecords.enumerated()), id: \.offset) { index, mySolplyRecord in
-                        mySolplyRecordRow(mySolplyRecord, showsDivider: mySolplyRecords.count - 1 != index)
+                    ForEach(Array(mySolplyRecordPreviews.enumerated()), id: \.offset) { index, mySolplyRecordPreview in
+                        mySolplyRecordRow(mySolplyRecordPreview, showsDivider: mySolplyRecordPreviews.count - 1 != index)
                     }
                 }
             } else {
@@ -162,27 +157,27 @@ private extension MyPageView {
         }
     }
     
-    func mySolplyRecordRow(_ mySolplyRecord: MySolplyRecord, showsDivider: Bool) -> some  View {
+    func mySolplyRecordRow(_ mySolplyRecordPreview: MySolplyRecordPreview, showsDivider: Bool) -> some  View {
         VStack(alignment: .center, spacing: 0) {
             HStack(alignment: .top, spacing: 12.adjustedWidth) {
                 ThumbnailImage(
-                    mySolplyRecord.PhotosUrls.first,
+                    mySolplyRecordPreview.previewImageUrl,
                     width: 72.adjusted,
                     height: 72.adjusted,
                     radius: 12
                 )
                 
                 VStack(alignment: .leading, spacing: 8.adjustedHeight) {
-                    Text(mySolplyRecord.placeName)
+                    Text(mySolplyRecordPreview.placeName)
                         .applySolplyFont(.title_15_m)
                         .foregroundStyle(.coreBlack)
                     
-                    Text(mySolplyRecord.recordText)
+                    Text(mySolplyRecordPreview.content)
                         .applySolplyFont(.body_14_r)
                         .foregroundStyle(.gray900)
                         .lineLimit(2)
                 }
-                .frame(width: 251.adjustedWidth, alignment: .center)
+                .frame(width: 251.adjustedWidth, alignment: .leading)
             }
             
             if showsDivider {

--- a/Solply/Solply/Presentation/MyPage/MyPage/View/MyPageView.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPage/View/MyPageView.swift
@@ -66,6 +66,11 @@ struct MyPageView: View {
         .background(.gray100)
         .ignoresSafeArea(edges: .bottom)
         .onAppear {
+            // TODO: - 내 솔플리 기록 삭제하고 돌아왔을 때 반영되지 않아서 임시로 유저정보 Fetch
+            // 해결하려면, 회원 정보 Fetch랑 내 솔플리 기록 Fetch랑, 내가 등록한 장소 Fetch를 나눠야 좋을 듯..
+            Task {
+                await appState.fetchUserInformation()
+            }
             store.dispatch(.fetchLoginInformation)
             
             AmplitudeManager.shared.track(.viewMyPage(entryMode: .member))

--- a/Solply/Solply/Presentation/MyPage/MySolplyRecords/Effect/MySolplyRecordsEffect.swift
+++ b/Solply/Solply/Presentation/MyPage/MySolplyRecords/Effect/MySolplyRecordsEffect.swift
@@ -36,4 +36,17 @@ extension MySolplyRecordsEffect {
             return .fetchMySolplyRecordsFailed(error: .unknownError)
         }
     }
+    
+    func removeMySolplyRecord(reviewId: Int) async -> MySolplyRecordsAction {
+        do {
+            let _ = try await placeService.removeMySolplyRecord(reviewId: reviewId)
+            
+            return .removeMySolplyRecordSuccess(reviewId: reviewId)
+            
+        } catch let error as NetworkError {
+            return .removeMySolplyRecordFailed(error: error)
+        } catch {
+            return .removeMySolplyRecordFailed(error: .unknownError)
+        }
+    }
 }

--- a/Solply/Solply/Presentation/MyPage/MySolplyRecords/Effect/MySolplyRecordsEffect.swift
+++ b/Solply/Solply/Presentation/MyPage/MySolplyRecords/Effect/MySolplyRecordsEffect.swift
@@ -1,0 +1,39 @@
+//
+//  MySolplyRecordsEffect.swift
+//  Solply
+//
+//  Created by 김승원 on 5/8/26.
+//
+
+import Foundation
+
+struct MySolplyRecordsEffect {
+    private let placeService: PlaceAPI
+    
+    init(placeService: PlaceAPI) {
+        self.placeService = placeService
+    }
+}
+
+// MARK: - PlaceAPI
+
+extension MySolplyRecordsEffect {
+    func fetchMySolplyRecords() async -> MySolplyRecordsAction {
+        do {
+            let response = try await placeService.fetchMySolplysRecords()
+            
+            guard let data = response.data else {
+                return .fetchMySolplyRecordsFailed(error: .responseError)
+            }
+            
+            let mySolplyRecords = data.reviews.map { MySolplyRecord(dto: $0) }
+            
+            return .fetchMySolplyRecordsSuccess(mySolplyRecords: mySolplyRecords)
+            
+        } catch let error as NetworkError {
+            return .fetchMySolplyRecordsFailed(error: error)
+        } catch {
+            return .fetchMySolplyRecordsFailed(error: .unknownError)
+        }
+    }
+}

--- a/Solply/Solply/Presentation/MyPage/MySolplyRecords/Effect/MySolplyRecordsEffect.swift
+++ b/Solply/Solply/Presentation/MyPage/MySolplyRecords/Effect/MySolplyRecordsEffect.swift
@@ -20,7 +20,7 @@ struct MySolplyRecordsEffect {
 extension MySolplyRecordsEffect {
     func fetchMySolplyRecords() async -> MySolplyRecordsAction {
         do {
-            let response = try await placeService.fetchMySolplysRecords()
+            let response = try await placeService.fetchMySolplyRecords()
             
             guard let data = response.data else {
                 return .fetchMySolplyRecordsFailed(error: .responseError)

--- a/Solply/Solply/Presentation/MyPage/MySolplyRecords/Intent/MySolplyRecordsAction.swift
+++ b/Solply/Solply/Presentation/MyPage/MySolplyRecords/Intent/MySolplyRecordsAction.swift
@@ -11,6 +11,9 @@ enum MySolplyRecordsAction {
     case onAppear
     case deleteRecord(index: Int)
     
+    case presentImageViewer(index: Int, imageUrls: [String?])
+    case dismissImageViewer
+    
     // api
     case fetchMySolplyRecords
     case fetchMySolplyRecordsSuccess(mySolplyRecords: [MySolplyRecord])

--- a/Solply/Solply/Presentation/MyPage/MySolplyRecords/Intent/MySolplyRecordsAction.swift
+++ b/Solply/Solply/Presentation/MyPage/MySolplyRecords/Intent/MySolplyRecordsAction.swift
@@ -9,10 +9,14 @@ import Foundation
 
 enum MySolplyRecordsAction {
     case onAppear
-    case deleteRecord
+    case deleteRecord(index: Int)
     
     // api
     case fetchMySolplyRecords
     case fetchMySolplyRecordsSuccess(mySolplyRecords: [MySolplyRecord])
     case fetchMySolplyRecordsFailed(error: NetworkError)
+    
+    case removeMySolplyRecord(reviewId: Int)
+    case removeMySolplyRecordSuccess(reviewId: Int)
+    case removeMySolplyRecordFailed(error: NetworkError)
 }

--- a/Solply/Solply/Presentation/MyPage/MySolplyRecords/Intent/MySolplyRecordsAction.swift
+++ b/Solply/Solply/Presentation/MyPage/MySolplyRecords/Intent/MySolplyRecordsAction.swift
@@ -10,4 +10,9 @@ import Foundation
 enum MySolplyRecordsAction {
     case onAppear
     case deleteRecord
+    
+    // api
+    case fetchMySolplyRecords
+    case fetchMySolplyRecordsSuccess(mySolplyRecords: [MySolplyRecord])
+    case fetchMySolplyRecordsFailed(error: NetworkError)
 }

--- a/Solply/Solply/Presentation/MyPage/MySolplyRecords/Intent/MySolplyRecordsStore.swift
+++ b/Solply/Solply/Presentation/MyPage/MySolplyRecords/Intent/MySolplyRecordsStore.swift
@@ -31,9 +31,18 @@ final class MySolplyRecordsStore: ObservableObject {
         case .onAppear:
             dispatch(.fetchMySolplyRecords)
             
+        case .deleteRecord(let index):
+            dispatch(.removeMySolplyRecord(reviewId: state.mySolplyRecords[index].id))
+            
         case .fetchMySolplyRecords:
             Task {
                 let result = await effect.fetchMySolplyRecords()
+                dispatch(result)
+            }
+            
+        case .removeMySolplyRecord(let reviewId):
+            Task {
+                let result = await effect.removeMySolplyRecord(reviewId: reviewId)
                 dispatch(result)
             }
             

--- a/Solply/Solply/Presentation/MyPage/MySolplyRecords/Intent/MySolplyRecordsStore.swift
+++ b/Solply/Solply/Presentation/MyPage/MySolplyRecords/Intent/MySolplyRecordsStore.swift
@@ -13,6 +13,13 @@ final class MySolplyRecordsStore: ObservableObject {
     // MARK: - Properties
     
     @Published private(set) var state = MySolplyRecordsState()
+    private let effect: MySolplyRecordsEffect
+    
+    // MARK: - Initializer
+    
+    init() {
+        self.effect = MySolplyRecordsEffect(placeService: PlaceService())
+    }
     
     // MARK: - Dispatch
     
@@ -20,6 +27,16 @@ final class MySolplyRecordsStore: ObservableObject {
         MySolplyRecordsReducer.reduce(state: &state, action: action)
         
         switch action {
+            
+        case .onAppear:
+            dispatch(.fetchMySolplyRecords)
+            
+        case .fetchMySolplyRecords:
+            Task {
+                let result = await effect.fetchMySolplyRecords()
+                dispatch(result)
+            }
+            
         default:
             break
         }

--- a/Solply/Solply/Presentation/MyPage/MySolplyRecords/State/MySolplyRecordsReducer.swift
+++ b/Solply/Solply/Presentation/MyPage/MySolplyRecords/State/MySolplyRecordsReducer.swift
@@ -16,6 +16,15 @@ enum MySolplyRecordsReducer {
         case .deleteRecord:
             break
             
+        case .presentImageViewer(let index, let imageUrls):
+            state.imageViewerItem = ImageViewerItem(
+                selectedIndex: index,
+                imageUrls: imageUrls
+            )
+            
+        case .dismissImageViewer:
+            state.imageViewerItem = nil
+            
         case .fetchMySolplyRecords:
             state.isLoading = true
             break

--- a/Solply/Solply/Presentation/MyPage/MySolplyRecords/State/MySolplyRecordsReducer.swift
+++ b/Solply/Solply/Presentation/MyPage/MySolplyRecords/State/MySolplyRecordsReducer.swift
@@ -11,9 +11,22 @@ enum MySolplyRecordsReducer {
     static func reduce(state: inout MySolplyRecordsState, action: MySolplyRecordsAction) {
         switch action {
         case .onAppear:
-            state.mySolplyRecords = MySolplyRecord.mock
+            break
+            
         case .deleteRecord:
             // state의 기록 갱신
+            break
+            
+        case .fetchMySolplyRecords:
+            state.isLoading = true
+            break
+            
+        case .fetchMySolplyRecordsSuccess(let mySolplyRecords):
+            state.mySolplyRecords = mySolplyRecords
+            state.isLoading = false
+            
+        case .fetchMySolplyRecordsFailed(let error):
+            print(error)
             break
         }
     }

--- a/Solply/Solply/Presentation/MyPage/MySolplyRecords/State/MySolplyRecordsReducer.swift
+++ b/Solply/Solply/Presentation/MyPage/MySolplyRecords/State/MySolplyRecordsReducer.swift
@@ -14,7 +14,6 @@ enum MySolplyRecordsReducer {
             break
             
         case .deleteRecord:
-            // state의 기록 갱신
             break
             
         case .fetchMySolplyRecords:
@@ -26,6 +25,17 @@ enum MySolplyRecordsReducer {
             state.isLoading = false
             
         case .fetchMySolplyRecordsFailed(let error):
+            print(error)
+            break
+            
+        case .removeMySolplyRecord:
+            break
+            
+        case .removeMySolplyRecordSuccess(let reviewId):
+            state.mySolplyRecords.removeAll { $0.id == reviewId }
+            break
+            
+        case .removeMySolplyRecordFailed(let error):
             print(error)
             break
         }

--- a/Solply/Solply/Presentation/MyPage/MySolplyRecords/State/MySolplyRecordsState.swift
+++ b/Solply/Solply/Presentation/MyPage/MySolplyRecords/State/MySolplyRecordsState.swift
@@ -10,4 +10,6 @@ import Foundation
 struct MySolplyRecordsState {
     var isLoading: Bool = true
     var mySolplyRecords: [MySolplyRecord] = []
+    
+    var imageViewerItem: ImageViewerItem? = nil
 }

--- a/Solply/Solply/Presentation/MyPage/MySolplyRecords/View/MySolplyRecordsView.swift
+++ b/Solply/Solply/Presentation/MyPage/MySolplyRecords/View/MySolplyRecordsView.swift
@@ -25,10 +25,15 @@ struct MySolplyRecordsView: View {
     
     var body: some View {
         mySolplyRecordsList
+            .customLoading(.mySolplyRecordsLoading, isLoading: store.state.isLoading)
             .customNavigationBar(.backWithTitle(title: "내 솔플리 기록", backAction: {
                 appCoordinator.goBack()
             }))
             .ignoresSafeArea(edges: .bottom)
+            .imageViewer(
+                item: store.state.imageViewerItem,
+                dismissAction: { store.dispatch(.dismissImageViewer) }
+            )
             .onAppear {
                 store.dispatch(.onAppear)
             }
@@ -95,13 +100,17 @@ extension MySolplyRecordsView {
             if !mySolplyRecord.PhotosUrls.isEmpty {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(alignment: .center, spacing: 8.adjustedWidth) {
-                        ForEach(mySolplyRecord.PhotosUrls, id: \.self) { thumbnailImageUrl in
+                        ForEach(Array(mySolplyRecord.PhotosUrls.enumerated()), id: \.offset) { index, thumbnailImageUrl in
                             ThumbnailImage(
                                 thumbnailImageUrl,
                                 width: 72.adjusted,
                                 height: 72.adjusted,
                                 radius: 12
                             )
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                store.dispatch(.presentImageViewer(index: index, imageUrls: mySolplyRecord.PhotosUrls))
+                            }
                         }
                     }
                 }

--- a/Solply/Solply/Presentation/MyPage/MySolplyRecords/View/MySolplyRecordsView.swift
+++ b/Solply/Solply/Presentation/MyPage/MySolplyRecords/View/MySolplyRecordsView.swift
@@ -39,18 +39,32 @@ struct MySolplyRecordsView: View {
 
 extension MySolplyRecordsView {
     private var mySolplyRecordsList: some View {
-        ScrollView(.vertical, showsIndicators: true) {
-            LazyVStack(alignment: .center, spacing: 0) {
-                ForEach(Array(store.state.mySolplyRecords.enumerated()), id: \.offset) { index,  mySolplyRecord in
-                    mySolplyRecordRow(mySolplyRecord, hideSeparator: store.state.mySolplyRecords.count - 1 == index)
+        Group {
+            if store.state.mySolplyRecords.isEmpty {
+                Text("등록한 기록이 없어요")
+                    .applySolplyFont(.body_16_r)
+                    .foregroundStyle(.gray600)
+                    .padding(.top, 300.adjustedHeight)
+            } else {
+                ScrollView(.vertical, showsIndicators: true) {
+                    LazyVStack(alignment: .center, spacing: 0) {
+                        ForEach(Array(store.state.mySolplyRecords.enumerated()), id: \.offset) { index,  mySolplyRecord in
+                            mySolplyRecordRow(
+                                mySolplyRecord,
+                                index: index,
+                                hideSeparator: store.state.mySolplyRecords.count - 1 == index
+                            )
+                        }
+                    }
+                    .padding(.bottom, 90.adjustedHeight)
                 }
             }
-            .padding(.bottom, 90.adjustedHeight)
         }
     }
     
     private func mySolplyRecordRow(
         _ mySolplyRecord: MySolplyRecord,
+        index: Int,
         hideSeparator: Bool
     ) -> some View {
         VStack(alignment: .leading, spacing: 16.adjustedHeight) {
@@ -65,7 +79,7 @@ extension MySolplyRecordsView {
                 
                 Button {
                     AlertManager.shared.showAlert(alertType: .deleteRecord, onCancel: nil) {
-                        // TODO: - 기록 삭제하기 API 연동
+                        store.dispatch(.deleteRecord(index: index))
                     }
                 } label: {
                     Image(.binIcon)

--- a/Solply/Solply/Presentation/Place/PlaceDetail/State/PlaceDetailReducer.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/State/PlaceDetailReducer.swift
@@ -131,6 +131,7 @@ enum PlaceDetailReducer {
             
         case .userTownsUpdated:
             state.shouldShowTownToast = false
+            state.shouldFetchUserInformation = true
             
         case .updateUserTownsFailed(let error):
             print(error)

--- a/Solply/Solply/Presentation/Place/PlaceDetail/State/PlaceDetailState.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/State/PlaceDetailState.swift
@@ -11,6 +11,7 @@ struct PlaceDetailState {
     var isPlaceDetailLoading: Bool = false
     
     var shouldShowTownToast: Bool = false
+    var shouldFetchUserInformation: Bool = false
     var shouldShowFindDirectionDialog: Bool = false
     var isAddToCourseSheetPresented: Bool = false
     

--- a/Solply/Solply/Presentation/Place/PlaceDetail/View/PlaceDetailView.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/View/PlaceDetailView.swift
@@ -131,6 +131,14 @@ struct PlaceDetailView: View {
                 message: "‘\(addPlaceCourseInformation.courseName.truncated(length: 8))’에 추가되었어요."
             )
         }
+        .onChange(of: store.state.shouldFetchUserInformation) { _, shouldFetchUserInformation in
+            if shouldFetchUserInformation {
+                Task {
+                    await appState.fetchUserInformation()
+                    
+                }
+            }
+        }
     }
 }
 

--- a/Solply/Solply/Presentation/Place/PlaceSearch/Component/SearchPlaceCard.swift
+++ b/Solply/Solply/Presentation/Place/PlaceSearch/Component/SearchPlaceCard.swift
@@ -82,5 +82,6 @@ struct SearchPlaceCard: View {
             Divider()
                 .overlay(Color.gray200)
         }
+        .background(.coreWhite)
     }
 }

--- a/Solply/Solply/Presentation/Record/RecordWrite/Effect/RecordWriteEffect.swift
+++ b/Solply/Solply/Presentation/Record/RecordWrite/Effect/RecordWriteEffect.swift
@@ -22,7 +22,7 @@ extension RecordWriteEffect {
         do {
             let _ = try await placeService.submitPlaceRecordWrite(request: request)
             
-            try await Task.sleep(for: .seconds(0.5))
+            try await Task.sleep(for: .seconds(1))
             
             return .submitPlaceRecordWriteSuccess
             

--- a/Solply/Solply/Presentation/Record/RecordWrite/Effect/RecordWriteEffect.swift
+++ b/Solply/Solply/Presentation/Record/RecordWrite/Effect/RecordWriteEffect.swift
@@ -22,6 +22,8 @@ extension RecordWriteEffect {
         do {
             let _ = try await placeService.submitPlaceRecordWrite(request: request)
             
+            try await Task.sleep(for: .seconds(0.5))
+            
             return .submitPlaceRecordWriteSuccess
             
         } catch let error as NetworkError {

--- a/Solply/Solply/Presentation/Record/RecordWrite/State/RecordWriteReducer.swift
+++ b/Solply/Solply/Presentation/Record/RecordWrite/State/RecordWriteReducer.swift
@@ -24,11 +24,11 @@ enum RecordWriteReducer {
             state.selectedPhotos = photos
             
         case .registerRecordButtonTapped:
+            state.isLoading = true
             break
             
         // api
         case .submitPlaceRecordWrite:
-            state.isLoading = true
             break
             
         case .submitPlaceRecordWriteSuccess:

--- a/Solply/Solply/Presentation/Record/RecordWrite/View/RecordWriteView.swift
+++ b/Solply/Solply/Presentation/Record/RecordWrite/View/RecordWriteView.swift
@@ -71,6 +71,7 @@ struct RecordWriteView: View {
                         .padding(.horizontal, 20.adjustedWidth)
                     
                     SolplyPhotosPicker(maxSelectionCount: 5) { imageData in
+                        hideKeyboard()
                         store.dispatch(.selectPhotos(imageData))
                     }
                 }

--- a/Solply/Solply/Presentation/TabBar/UserInformation.swift
+++ b/Solply/Solply/Presentation/TabBar/UserInformation.swift
@@ -15,6 +15,8 @@ struct UserInformation : Hashable {
     let townId: Int
     let profileImageUrl: String?
     let myPlacePreviews: [UserPlace]
+    let mySolplyRecordPreviews: [MySolplyRecordPreview]
+    let hasMoreReviews: Bool
 }
 
 extension UserInformation {
@@ -26,5 +28,7 @@ extension UserInformation {
         townId = dto.selectedTown.townId
         profileImageUrl = dto.profileImageUrl
         myPlacePreviews = dto.myPlacePreviews.map(UserPlace.init)
+        mySolplyRecordPreviews = dto.myReviewPreview.reviews.map { MySolplyRecordPreview(dto: $0) }
+        hasMoreReviews = dto.myReviewPreview.hasMoreReviews
     }
 }


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 내 솔플리 기록 관련된 API 연동했습니다.
- 마이페이지 -> 내 솔플리 기록 섹션 추가
- 내 솔플리 기록 전체 보기 API 연동
- 내 솔플리 기록 삭제 API 연동
- 추가적으로 지금 기록 삭제를 하고 마이페이지로 돌아오면, api를 재호출하지 않아서 마이페이지에 내 솔플리 기록 섹션이 갱신되지 않기 때문에,, 일단 임시로 마이페이지뷰의 onAppear에 유저 정보 조회 API를 호출하도록 해놨습니닷(이슈파서 해결할게요)
- 그리고 기록 작성하고 장소 상세뷰로 돌아왔을 때 사진이 S3 서버에 업로드 되는 타이밍 전에 Api를 호출하게 되어 사진이 화면에 보이지 않는(아에 빈 배열로 내려옴) 버그가 있어서, 기록을 작성할 때 1초 기다렸다가 이전 화면으로(장소 상세 뷰)돌아가도록 해놨어요.

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| A 기능 | <img src = "https://github.com/user-attachments/assets/1ed6c70c-780e-459a-9b4f-1965630947a6" width ="250"> | <img src = "" width ="250"> |

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #509 

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 조금만 더 힘내봅시다..
