### PR TITLE
[fix/#516] AI 추천 동네 선택 "전체" 옵션 추가

### DIFF
--- a/Solply/Solply/Network/DTO/Town/ResponseDTO/TownListResponseDTO.swift
+++ b/Solply/Solply/Network/DTO/Town/ResponseDTO/TownListResponseDTO.swift
@@ -18,36 +18,30 @@ struct TownDTO: ResponseModelType {
 struct TownListResponseDTO: ResponseModelType {
     let towns: [TownDTO]
     
-    func toEntity() -> [Town] {
-        let parentTowns = towns.filter { town in
-            return town.parentTownId == nil
-        }
-
-        var structuredTownList: [Town] = []
-
-        for parent in parentTowns {
-            var subTownList: [SubTown] = []
-
-            for child in towns {
-                if child.parentTownId == parent.townId {
-                    let subTown = SubTown(
-                        id: child.townId,
-                        townName: child.townName
-                    )
-                    subTownList.append(subTown)
-                }
+    func toEntity(includeAllOption: Bool = false) -> [Town] {
+        let childrenByParentId = Dictionary(grouping: towns) { $0.parentTownId }
+        
+        let parentTowns = towns.filter { $0.parentTownId == nil }
+        
+        return parentTowns.map { parent in
+            let childSubTowns = (childrenByParentId[parent.townId] ?? []).map { child in
+                SubTown(id: child.townId, townName: child.townName)
             }
-
-            let town = Town(
+            
+            let subTowns: [SubTown]
+            if includeAllOption {
+                let allSubTown = SubTown(id: parent.townId, townName: "전체")
+                subTowns = [allSubTown] + childSubTowns
+            } else {
+                subTowns = childSubTowns
+            }
+            
+            return Town(
                 id: parent.townId,
                 townName: parent.townName,
-                subTowns: subTownList
+                subTowns: subTowns
             )
-            
-            structuredTownList.append(town)
         }
-
-        return structuredTownList
     }
 }
 

--- a/Solply/Solply/Presentation/AIRecommend/AIRecommendPrompt/Effect/AIRecommendPromptEffect.swift
+++ b/Solply/Solply/Presentation/AIRecommend/AIRecommendPrompt/Effect/AIRecommendPromptEffect.swift
@@ -125,7 +125,7 @@ extension AIRecommendPromptEffect {
                 return .fetchTownsFailure(error: .responseError)
             }
             
-            let towns = data.toEntity()
+            let towns = data.toEntity(includeAllOption: true)
             
             return .fetchTownsSuccess(townList: towns)
         } catch let error as NetworkError {

--- a/Solply/Solply/Presentation/AIRecommend/AIRecommendPrompt/State/AIRecommendPromptState.swift
+++ b/Solply/Solply/Presentation/AIRecommend/AIRecommendPrompt/State/AIRecommendPromptState.swift
@@ -34,7 +34,11 @@ struct AIRecommendPromptState {
     var selectedSubTown: SubTown? = nil
     
     var selectTownHeader: String {
-        selectedSubTown?.townName ?? ""
+        guard let selectedSubTown else { return "" }
+        
+        let isAllSelected = selectedSubTown.id == selectedTown?.id
+        
+        return isAllSelected ? (selectedTown?.townName ?? "") : selectedSubTown.townName
     }
     
     var examplePhrases: [String] {


### PR DESCRIPTION
"전체" 옵션을 포함할 수 있게 분기처리 추가

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- AI 추천 동네 선택에 "전체" 옵션을 추가했습니다아
- "전체" 옵션 선택 후 돌아왔을 때 표시될 텍스트도 "전체"인지는 아직 미정이라 디쌤들한테 답 받으면 추가로 수정할게요

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| 전체 선택 가능! | <img src = "https://github.com/user-attachments/assets/87414701-033f-4702-84e1-ebcd2c9322b2" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 구현 방법 & 개선된 점
어떻게 기존 동네API에서 서버를 수정하지 않고 "전체" 옵션을 추가할까 고민하다가 서버에서 내려주는 값에 끼워넣으면 되겠다 싶어서 아래와 같이 수정했어요

```Swift
// TownListResponseDTO.swift 기존 코드
struct TownListResponseDTO: ResponseModelType {
    let towns: [TownDTO]

    func toEntity() -> [Town] {
        let parentTowns = towns.filter { town in
            return town.parentTownId == nil
        }

        var structuredTownList: [Town] = []

        for parent in parentTowns {
            var subTownList: [SubTown] = []

            for child in towns {
                if child.parentTownId == parent.townId {
                    let subTown = SubTown(
                        id: child.townId,
                        townName: child.townName
                    )
                    subTownList.append(subTown)
                }
            }

            let town = Town(
                id: parent.townId,
                townName: parent.townName,
                subTowns: subTownList
            )

            structuredTownList.append(town)
        }

        return structuredTownList
    }
}
```
이게 원래 코드인데,
1. `parentTownId`가 `nil`인 것들만 걸러서 최상위 동네를 찾은 다음에 (예를 들어 서울 -> townId 1)
2. 각 최상위 동네에 대해 전체 `towns` 배열을 다시 순회하면서 `child.parentTownId == parent.townId`인 것들을 찾아서 `SubTown`으로 만듦 (서울 아래에 망원 연희 등등 묶이는 것)

```Swift
[
  Town(id: 1, townName: "서울", subTowns: [
    SubTown(id: 2, townName: "망원"),
    SubTown(id: 3, townName: "연희"),
    SubTown(id: 4, townName: "연남·홍대"),
    SubTown(id: 5, townName: "합정·상수"),
    SubTown(id: 6, townName: "서촌"),
    SubTown(id: 7, townName: "북촌·종로"),
  ])
]
```
결과적으로 데이터가 이렇게 변환되게 되죠.
여기에 `SubTown(id: 1, townName: "전체")`를 끼워넣도록 해서 구현했습니다.
추가적으로 기존 방법은 이중 for문이라 시간복잡도가 `O(n^2)`라서 뭐 지금은 동네가 많이 없어서 괜찮지만, 나중에 추가된다면 좀 느려질 수도 있을 거 같아서 함께 개선했습니다.

```Swift
struct TownListResponseDTO: ResponseModelType {
    let towns: [TownDTO]
    
    func toEntity(includeAllOption: Bool = false) -> [Town] { // <= 전체 옵션이 필요한지 bool값 추가
        // parentTownId를 기준으로 미리 그룹핑을 함! (그래서 한 번만 순회하면 된다)
        let childrenByParentId = Dictionary(grouping: towns) { $0.parentTownId }
        
        let parentTowns = towns.filter { $0.parentTownId == nil }
        
        return parentTowns.map { parent in
            let childSubTowns = (childrenByParentId[parent.townId] ?? []).map { child in
                SubTown(id: child.townId, townName: child.townName)
            }
            
            let subTowns: [SubTown]
            if includeAllOption {
                let allSubTown = SubTown(id: parent.townId, townName: "전체")
                subTowns = [allSubTown] + childSubTowns
            } else {
                subTowns = childSubTowns
            }
            
            return Town(
                id: parent.townId,
                townName: parent.townName,
                subTowns: subTowns
            )
        }
    }
}
```
바뀐 점을 설명하자면
1. `Dictionary(grouping: towns) { $0.parentTownId }` -> towns 배열을 한 번만 순회하면서 `parentTownId`를 키로 하는 딕셔너리를 생성함. 그러니까 부모 밑에 어떤 자식들이 있는지를 미리 계산함
2. 각 부모마다 자식을 찾을 때 더 이상 전체 배열을 돌지 않고, `childrenByParentId[parent.townId]`로 딕셔너리에서 바로 꺼낼 수 있음! O(1)이래요. 결국 전체 알고리즘의 시간복잡도는 O(1)이 아니라 O(n)이 되겟죠.

#### Dictionary(grouping:by:)란?
[공식문서입니다](https://developer.apple.com/documentation/swift/dictionary/init(grouping:by:))
<img width="704" height="381" alt="스크린샷 2026-07-05 00 18 02" src="https://github.com/user-attachments/assets/079f9591-f998-4f8e-b53e-7c44c40a5ca3" />
쉽게 말하자면 공식문서에 나온 예시처럼 배열의 원소를 뽑아서 그 값을 키값으로 하고, 같은 키를 가진 원소들끼리 자동으로 배열로 묶어서 `[Key: [Value]]`의 형태로 딕셔너리를 만들어요.
그러면 우리의 데이터가 어떤식으로 딕셔너리가 만들어지냐면

```Swift
[
    nil: [TownDTO(townId: 1, townName: "서울", parentTownId: nil)], // <- 최상위 동네들 묶음, parentTownId가 nil인 애들 배열
    1: [ // <- SubTown 둥네, parentTownId가 1 애들 배열
        TownDTO(townId: 2, townName: "망원", parentTownId: 1),
        TownDTO(townId: 3, townName: "연희", parentTownId: 1),
        TownDTO(townId: 4, townName: "연남·홍대", parentTownId: 1),
        ...
    ]
]
```
`[Int?: [TownDTO]]`타입의 딕셔너리가 만들어짐니다. 여기서 하나씩 쏙쏙 뽑아 쓰면 되는 거죠.


```Swift
let subTowns: [SubTown]
if includeAllOption {
    let allSubTown = SubTown(id: parent.townId, townName: "전체")
    subTowns = [allSubTown] + childSubTowns
} else {
    subTowns = childSubTowns
}
```
이제 "전체" 옵션을 추가한 방식인데요, `includeAllOption` 변수를 추가해서 분기처리를 했어요. "전체"옵션은 제일 처음 와야하기 때문에 `let allSubTown = SubTown(id: parent.townId, townName: "전체")`를 만들고, `allSubTown`을 0번으로 하는 배열에다가 뒤에 `SubTown`들을 붙였어요.
그러면 `["전체", "망원", "연희", ...]` 로 배열이 완성됩니다~ 뷰에서는 그냥 받아 사용하기만 하면 됨

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #516 

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
https://developer-fury.tistory.com/70
https://developer.apple.com/documentation/swift/dictionary/init(grouping:by:)

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
