### PR TITLE
[feat/#511] 장소 리뷰 신고 API 연동

### DIFF
--- a/Solply/Solply/Global/Coordinator/Destination/AppDestination.swift
+++ b/Solply/Solply/Global/Coordinator/Destination/AppDestination.swift
@@ -26,7 +26,7 @@ enum AppDestination: Hashable {
     case recordWrite(placeId: Int, placeName: String)
     case aiRecommendPrompt
     case aiRecommendResult(prompt: String, cards: [AIRecommendCard])
-    case placeComplaint
+    case placeComplaint(reviewId: Int)
     case mySolplyRecords
 }
 
@@ -70,8 +70,8 @@ extension AppDestination {
             AIRecommendPromptView()
         case .aiRecommendResult(let prompt, let cards):
             AIRecommendResultView(prompt: prompt, cards: cards)
-        case .placeComplaint:
-            PlaceComplaintView()
+        case .placeComplaint(let reviewId):
+            PlaceComplaintView(reviewId: reviewId)
         case .mySolplyRecords:
             MySolplyRecordsView()
         }

--- a/Solply/Solply/Global/Enum/ComplaintType.swift
+++ b/Solply/Solply/Global/Enum/ComplaintType.swift
@@ -7,21 +7,30 @@
 
 import Foundation
 
-enum ComplaintType: String, CaseIterable {
-    
-    case irrelevantContent = "IRRELEVANT_CONTENT"
+enum ComplaintType: String, CaseIterable, Codable {
+
+    case irrelevantToPlace = "IRRELEVANT_TO_PLACE"
     case abusiveLanguage = "ABUSIVE_LANGUAGE"
     case privacyViolation = "PRIVACY_VIOLATION"
     case falseInformation = "FALSE_INFORMATION"
-    case others = "OTHERS"
-    
+    case other = "OTHER"
+
     var title: String {
         switch self {
-        case .irrelevantContent: return "장소와 무관한 내용이에요"
-        case .abusiveLanguage: return "욕설/비방이 포함되어 있어요"
-        case .privacyViolation: return "타인의 얼굴/개인정보가 노출되었어요"
-        case .falseInformation: return "허위 정보가 포함되어 있어요"
-        case .others: return "기타(직접 입력)"
+        case .irrelevantToPlace:
+            return "장소와 무관한 내용이에요"
+
+        case .abusiveLanguage:
+            return "욕설/비방이 포함되어 있어요"
+
+        case .privacyViolation:
+            return "타인의 얼굴/개인정보가 노출되었어요"
+
+        case .falseInformation:
+            return "허위 정보가 포함되어 있어요"
+
+        case .other:
+            return "기타(직접 입력)"
         }
     }
 }

--- a/Solply/Solply/Network/API/PlaceAPI.swift
+++ b/Solply/Solply/Network/API/PlaceAPI.swift
@@ -61,4 +61,8 @@ protocol PlaceAPI {
     
     /// 내 장소 리뷰(기록) 삭제
     func removeMySolplyRecord(reviewId: Int) async throws -> BaseResponseBody<EmptyResponseDTO>
+    
+    /// 장소 리뷰 신고
+    func reportReview(reviewId: Int, request: PlaceReviewReportRequestDTO) async throws ->
+        BaseResponseBody<EmptyResponseDTO>
 }

--- a/Solply/Solply/Network/DTO/Complaint/RequestDTO/PlaceComplaintRequestDTO.swift
+++ b/Solply/Solply/Network/DTO/Complaint/RequestDTO/PlaceComplaintRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  PlaceComplaintRequestDTO.swift
+//  Solply
+//
+//  Created by sun on 7/4/26.
+//
+
+import Foundation
+
+struct PlaceReviewReportRequestDTO: Encodable {
+    let reportType: ComplaintType
+}

--- a/Solply/Solply/Network/Service/PlaceService.swift
+++ b/Solply/Solply/Network/Service/PlaceService.swift
@@ -94,4 +94,10 @@ extension PlaceService: PlaceAPI {
     func removeMySolplyRecord(reviewId: Int) async throws -> BaseResponseBody<EmptyResponseDTO> {
         return try await self.request(with: .removeMySolplyRecord(reviewId: reviewId))
     }
+    
+    func reportReview(reviewId: Int, request: PlaceReviewReportRequestDTO) async throws -> BaseResponseBody<EmptyResponseDTO> {
+        return try await self.request(with: .reportReview(reviewId: reviewId, request: request
+            )
+        )
+    }
 }

--- a/Solply/Solply/Network/TargetType/PlaceTargetType.swift
+++ b/Solply/Solply/Network/TargetType/PlaceTargetType.swift
@@ -29,6 +29,7 @@ enum PlaceTargetType {
     case fetchPlaceRecordList(placeId: Int)
     case fetchMySolplyRecords
     case removeMySolplyRecord(reviewId: Int)
+    case reportReview(reviewId: Int, request: PlaceReviewReportRequestDTO)
 }
 
 extension PlaceTargetType: BaseTargetType {
@@ -64,6 +65,8 @@ extension PlaceTargetType: BaseTargetType {
             return "/places/reviews/me"
         case .removeMySolplyRecord(let reviewId):
             return "/places/reviews/\(reviewId)"
+        case .reportReview(let reviewId, _):
+            return "/places/reviews/\(reviewId)/reports"
         }
     }
     
@@ -82,6 +85,7 @@ extension PlaceTargetType: BaseTargetType {
         case .fetchPlaceRecordList: return .get
         case .fetchMySolplyRecords: return .get
         case .removeMySolplyRecord: return .delete
+        case .reportReview: return .post
         }
     }
     
@@ -143,6 +147,8 @@ extension PlaceTargetType: BaseTargetType {
             return .requestPlain
         case .removeMySolplyRecord:
             return .requestPlain
+        case .reportReview(_, let request):
+            return .requestJSONEncodable(request)
         }
     }
 }

--- a/Solply/Solply/Presentation/Complaint/Effect/PlaceComplaintEffect.swift
+++ b/Solply/Solply/Presentation/Complaint/Effect/PlaceComplaintEffect.swift
@@ -1,0 +1,40 @@
+//
+//  PlaceComplaintEffect.swift
+//  Solply
+//
+//  Created by sun on 7/4/26.
+//
+
+import Foundation
+
+struct PlaceComplaintEffect {
+    private let placeService: PlaceAPI
+
+    init(placeService: PlaceAPI) {
+        self.placeService = placeService
+    }
+
+    func reportReview(
+        reviewId: Int,
+        reportType: ComplaintType
+    ) async -> PlaceComplaintAction {
+        do {
+            let request = PlaceReviewReportRequestDTO(
+                reportType: reportType
+            )
+
+            _ = try await placeService.reportReview(
+                reviewId: reviewId,
+                request: request
+            )
+
+            return .complaintSuccess
+
+        } catch let error as NetworkError {
+            return .complaintFailed(error: error)
+
+        } catch {
+            return .complaintFailed(error: .unknownError)
+        }
+    }
+}

--- a/Solply/Solply/Presentation/Complaint/Intent/PlaceComplaintAction.swift
+++ b/Solply/Solply/Presentation/Complaint/Intent/PlaceComplaintAction.swift
@@ -5,11 +5,8 @@
 //  Created by sun on 4/17/26.
 //
 
-import Foundation
-
 enum PlaceComplaintAction {
     case selectComplaintType(ComplaintType)
-    case updateContent(String)
     case complaint
     case complaintSuccess
     case complaintFailed(error: NetworkError)

--- a/Solply/Solply/Presentation/Complaint/Intent/PlaceComplaintStore.swift
+++ b/Solply/Solply/Presentation/Complaint/Intent/PlaceComplaintStore.swift
@@ -10,34 +10,44 @@ import Foundation
 @MainActor
 final class PlaceComplaintStore: ObservableObject {
     @Published private(set) var state = PlaceComplaintState()
-    
+
+    private let reviewId: Int
+    private let effect: PlaceComplaintEffect
+
+    init(
+        reviewId: Int,
+        effect: PlaceComplaintEffect = PlaceComplaintEffect(placeService: PlaceService())
+    ) {
+        self.reviewId = reviewId
+        self.effect = effect
+    }
+
     func dispatch(_ action: PlaceComplaintAction) {
         PlaceComplaintReducer.reduce(state: &state, action: action)
-        
+
         switch action {
         case .complaint:
             guard let selectedComplaintType = state.selectedComplaintType else { return }
-            
-            let trimmedContent = state.content
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            
-            if selectedComplaintType == .others && trimmedContent.isEmpty {
-                return
-            }
-            
+
             AlertManager.shared.showAlert(
                 alertType: .complaint,
                 onCancel: nil
             ) { [weak self] in
-                self?.dispatch(.complaintSuccess)
+                guard let self else { return }
+
+                Task {
+                    let action = await self.effect.reportReview(
+                        reviewId: self.reviewId,
+                        reportType: selectedComplaintType
+                    )
+
+                    self.dispatch(action)
+                }
             }
-            
-        case .complaintSuccess:
-            break
-            
+
         case .complaintFailed(let error):
             print(error)
-            
+
         default:
             break
         }

--- a/Solply/Solply/Presentation/Complaint/State/PlaceComplaintReducer.swift
+++ b/Solply/Solply/Presentation/Complaint/State/PlaceComplaintReducer.swift
@@ -12,24 +12,15 @@ enum PlaceComplaintReducer {
         switch action {
         case .selectComplaintType(let complaintType):
             state.selectedComplaintType = complaintType
-            
-            if complaintType != .others {
-                state.content = ""
-            }
-            
-        case .updateContent(let text):
-            state.content = String(text.prefix(200))
-            
+
         case .complaint:
             break
-            
+
         case .complaintSuccess:
             state.showComplaintCompleteModal = true
-            break
-            
+
         case .complaintFailed(let error):
-            print(error)
-            break
+            state.error = error
         }
     }
 }

--- a/Solply/Solply/Presentation/Complaint/State/PlaceComplaintState.swift
+++ b/Solply/Solply/Presentation/Complaint/State/PlaceComplaintState.swift
@@ -9,7 +9,6 @@ import Foundation
 
 struct PlaceComplaintState {
     var selectedComplaintType: ComplaintType?
-    var content: String = ""
     var showComplaintCompleteModal: Bool = false
     var error: NetworkError?
 }

--- a/Solply/Solply/Presentation/Complaint/View/PlaceComplaintView.swift
+++ b/Solply/Solply/Presentation/Complaint/View/PlaceComplaintView.swift
@@ -8,28 +8,31 @@
 import SwiftUI
 
 struct PlaceComplaintView: View {
-    
+
     // MARK: - Properties
-    
+
     @EnvironmentObject private var appCoordinator: AppCoordinator
-    @StateObject private var store = PlaceComplaintStore()
-    
+    @StateObject private var store: PlaceComplaintStore
+
+    private let reviewId: Int
+
+    // MARK: - Initializer
+
+    init(reviewId: Int) {
+        self.reviewId = reviewId
+        _store = StateObject(
+            wrappedValue: PlaceComplaintStore(reviewId: reviewId)
+        )
+    }
+
     // MARK: - Body
-    
+
     var body: some View {
         VStack(alignment: .center, spacing: 0) {
             complaintTypeList
-            
-            if store.state.selectedComplaintType == .others {
-                SolplyTextEditor(
-                    onTextChanged: { text in
-                        store.dispatch(.updateContent(text))
-                    }
-                )
-            }
-            
+
             Spacer()
-            
+
             nextButton
         }
         .customNavigationBar(
@@ -38,10 +41,6 @@ struct PlaceComplaintView: View {
                 backAction: { appCoordinator.goBack() }
             )
         )
-        .ignoresSafeArea(.keyboard)
-        .onTapGesture {
-            hideKeyboard()
-        }
         .customAlert()
         .overlay(alignment: .center) {
             if store.state.showComplaintCompleteModal {
@@ -54,26 +53,18 @@ struct PlaceComplaintView: View {
 }
 
 extension PlaceComplaintView {
-    
+
     private var isNextEnabled: Bool {
-        guard let selectedComplaintType = store.state.selectedComplaintType else { return false }
-        
-        if selectedComplaintType == .others {
-            return !store.state.content
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .isEmpty
-        }
-        
-        return true
+        store.state.selectedComplaintType != nil
     }
-    
+
     private var complaintTypeList: some View {
         VStack(alignment: .center, spacing: 0) {
             ForEach(ComplaintType.allCases, id: \.self) { complaint in
                 SolplySelectRow(
                     title: complaint.title,
                     isSelected: store.state.selectedComplaintType == complaint,
-                    hideSeparator: store.state.selectedComplaintType == complaint && complaint == .others
+                    hideSeparator: false
                 ) {
                     store.dispatch(.selectComplaintType(complaint))
                 }
@@ -82,7 +73,7 @@ extension PlaceComplaintView {
         .padding(.horizontal, 20.adjustedWidth)
         .padding(.top, 16.adjustedHeight)
     }
-    
+
     private var nextButton: some View {
         SolplyMainButton(
             title: "다음",

--- a/Solply/Solply/Presentation/Place/PlaceDetail/View/PlaceDetailView.swift
+++ b/Solply/Solply/Presentation/Place/PlaceDetail/View/PlaceDetailView.swift
@@ -413,7 +413,7 @@ extension PlaceDetailView {
                             },
                             reportAction: {
                                 appState.requireLoginWithAlert(
-                                    onAuthenticated: { appCoordinator.navigate(to: .placeComplaint) },
+                                    onAuthenticated: { appCoordinator.navigate(to: .placeComplaint(reviewId: record.id)) },
                                     onExplore: { appCoordinator.changeRoot(to: .auth) }
                                 )
                             }

--- a/Solply/Solply/Presentation/Record/RecordList/View/RecordListView.swift
+++ b/Solply/Solply/Presentation/Record/RecordList/View/RecordListView.swift
@@ -27,7 +27,7 @@ struct RecordListView: View {
         ScrollView(.vertical, showsIndicators: true) {
             VStack(alignment: .center, spacing: 20.adjustedHeight) {
                 RecordWriteButton {
-                    appCoordinator.navigate(to: .recordWrite(placeId: store.placeId, placeName: store.placeName)) 
+                    appCoordinator.navigate(to: .recordWrite(placeId: store.placeId, placeName: store.placeName))
                 }
                 
                 recordList
@@ -65,7 +65,11 @@ extension RecordListView {
                         store.dispatch(.presentImageViewer(index: index, imageUrls: record.photoUrls))
                     }, reportAction: {
                         appState.requireLoginWithAlert(
-                            onAuthenticated: { appCoordinator.navigate(to: .placeComplaint) },
+                            onAuthenticated: {
+                                appCoordinator.navigate(
+                                    to: .placeComplaint(reviewId: record.id)
+                                )
+                            },
                             onExplore: { appCoordinator.changeRoot(to: .auth) }
                         )
                     }


### PR DESCRIPTION
## 📄 작업 내용
- 서버 요청 스펙에 맞게 `ComplaintType`을 수정하고, 신고 타입을 서버 enum 값과 동일하게 정의햇습니닷
- 리뷰 신고 API를 추가하고 신고 화면과 연동
- 리뷰별 신고를 위해 `reviewId`를 전달하도록 네비게이션을 수정함

> api 연결 pr이라서 기기대응은 안햇습니닷 (장소 리뷰 추가해주셔서 감사요)

|    구현 내용    |   iPhone 17 pro   | 
| :-------------: | :----------: | 
| API 요청 성공~ | <img src = "https://github.com/user-attachments/assets/f18a229a-adfe-4084-8996-0e2870cc53f7" width ="250"> | 
| 한번 신고보내면 api 호출은 되는데 응답이 제대로 안옴 <br> 그래서 모달 화면이 제대로 안넘어감 | <img src = "https://github.com/user-attachments/assets/3bcaba06-41d7-48a9-9cc6-5988eb8f0be0" width ="250"> | 

지금 문제가! 한 번 신고했던 리뷰는 400 에러가 오더라구용
이거 관련해서 서버샘들께 말씀해두겟슴니닷

## 💻 주요 코드 설명
### 리뷰 신고 API 연동을 위한 `reviewId` 전달
```Swift
func reportReview(
    reviewId: Int,
    reportType: ComplaintType
) async -> PlaceComplaintAction {
    let request = PlaceComplaintRequestDTO(reportType: reportType)

    _ = try await placeService.reportReview(
        reviewId: reviewId,
        request: request
    )

    return .complaintSuccess
}
```

장소 리뷰 신고 API는 reviewId를 파라미터로 사용하기 때문에,
신고 화면 진입 시 선택한 리뷰의 reviewId를 전달하도록 네비게이션을 수정햇습니다!!

이후 View → Store → Effect로 reviewId와 선택한 신고 사유를 전달하여 신고 요청을 수행하도록 구현햇습니다아

## 🔗 연결된 이슈
- Connected: #511

## 👀 기타 더 이야기해볼 점
> 오랜만에 MVI이라... 맞는지 잘모르겟네용 허허

<img width="200" alt="스크린샷 2026-07-05 23 34 33" src="https://github.com/user-attachments/assets/d7f5e02a-76e2-4794-821c-7900ae0df034" /> 이번주도 화이띵
