### PR TITLE
[chore/#521] 마이페이지 내 솔플리 기록 전체보기 수정

### DIFF
--- a/Solply/Solply/Presentation/MyPage/MyPage/View/MyPageView.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPage/View/MyPageView.swift
@@ -117,10 +117,11 @@ private extension MyPageView {
         VStack(alignment: .center, spacing: 16.adjustedHeight) {
             sectionHeader(
                 title: "내 솔플리 기록",
-                isButtonEnabled: appState.userInformation?.hasMoreReviews ?? false) {
-                    appCoordinator.navigate(to: .mySolplyRecords)
-                    
-                }
+                isButtonEnabled: appState.userInformation?.hasMoreReviews ?? false
+            ) {
+                appCoordinator.navigate(to: .mySolplyRecords)
+                
+            }
             
             mySolplyRecordList()
         }

--- a/Solply/Solply/Presentation/TabBar/UserInformation.swift
+++ b/Solply/Solply/Presentation/TabBar/UserInformation.swift
@@ -29,6 +29,6 @@ extension UserInformation {
         profileImageUrl = dto.profileImageUrl
         myPlacePreviews = dto.myPlacePreviews.map(UserPlace.init)
         mySolplyRecordPreviews = dto.myReviewPreview.reviews.map { MySolplyRecordPreview(dto: $0) }
-        hasMoreReviews = dto.myReviewPreview.hasMoreReviews
+        hasMoreReviews = !mySolplyRecordPreviews.isEmpty
     }
 }


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 마이페이지에 내 솔플리 기록이 1개 이상 있으면 "전체보기> " 버튼이 활성화 되게끔 수정했어요

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| A 기능 | <img src = "https://github.com/user-attachments/assets/040f0bac-6da9-4f57-9595-f8f8db436daa" width ="250"> |

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #521 

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 원래 서버에서 내려주는 값을 사용했는데, 이제 1개 이상만 있어도 "전체보기"가 활성화 되어야 하기 때문에, isEmpty를 활용해서 수정했ㅅ브니돠 초간단 수정
