### PR TITLE
[chore/#519] 알림 아이콘 투명화

### DIFF
--- a/Solply/Solply/Global/Enum/NavigationBarType.swift
+++ b/Solply/Solply/Global/Enum/NavigationBarType.swift
@@ -13,7 +13,8 @@ enum NavigationBarType {
     case backWithTitleAndHome(title: String?, backAction: (() -> Void), homeAction: (() -> Void))
     case backWithTitle(title: String, backAction: (() -> Void))
     case backOnly(backAction: (() -> Void))
-    case titleWithNotification(title: String, notificationAction: (() -> Void))
+    case titleWithNotification(title: String/*, notificationAction: (() -> Void)*/)
+    // TODO: - 알림 구현 시 원상복구 !!!
     case townFilterWithSearch(filterTitle: String, isLoading: Bool, filterAction: (() -> Void), aiAction: (() -> Void), searchAction: (() -> Void))
     case floating(backAction: (() -> Void), homeAction: (() -> Void))
     case dismissWithImageCount(dismissAction: (() -> Void), imageCount: String)

--- a/Solply/Solply/Global/Modifier/CustomNavigationBarModifier.swift
+++ b/Solply/Solply/Global/Modifier/CustomNavigationBarModifier.swift
@@ -67,12 +67,17 @@ struct CustomNavigationBarModifier: ViewModifier {
                     backgroundColor: .clear
                 )
             )
-        case .titleWithNotification(let title, let notificationAction):
+        case .titleWithNotification(let title/*, let notificationAction*/):
+            // TODO: - 알림 구현 시 원상복구 !!!
             content.modifier(
                 LayoutNavigationBarModifier(
                     centerView: { EmptyView() },
                     leftView: { titleItem(title, isLargeTitle: true) },
-                    rightView: { barButtonItem(.alarmIcon, action: notificationAction) },
+                    rightView: {
+                        //TODO: - 알림 구현 시 원상복구하기 !!
+                        /*barButtonItem(.alarmIcon, action: notificationAction)*/
+                        EmptyView()
+                    },
                     backgroundColor: .clear
                 )
             )

--- a/Solply/Solply/Presentation/Archive/Archive/View/ArchiveView.swift
+++ b/Solply/Solply/Presentation/Archive/Archive/View/ArchiveView.swift
@@ -24,8 +24,9 @@ struct ArchiveView: View {
         }
         .customNavigationBar(
             .titleWithNotification(
-                title: "수집함",
-                notificationAction: { print("알림") }
+                title: "수집함"
+//                notificationAction: { print("알림") }
+                // TODO: - 알림 구현 시 원상복구 ....
             )
         )
         .ignoresSafeArea(edges: .bottom)

--- a/Solply/Solply/Presentation/MyPage/MyPage/View/MyPageView.swift
+++ b/Solply/Solply/Presentation/MyPage/MyPage/View/MyPageView.swift
@@ -58,8 +58,9 @@ struct MyPageView: View {
         }
         .customNavigationBar(
             .titleWithNotification(
-                title: "마이페이지",
-                notificationAction: { print("알림") }
+                title: "마이페이지"
+//                notificationAction: { print("알림") }
+                // TODO: - 알림 구현 시 원상복구 ....
             )
         )
         .background(.gray100)


### PR DESCRIPTION
## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 마이페이지와 수집함 뷰의 알림 아이콘을 투명화했습니다.
- 이후, 알림 기능 구현 시 다시 쓸 수 있도록 주석처리 하고 'TODO' 달아두었습니다.

|    구현 내용    |   iPhone 13 mini   |   iPhone 17 pro   |
| :-------------: | :----------: | :----------: |
| 마이페이지 | <img src = "https://github.com/user-attachments/assets/bbbe60b7-f5eb-4696-ab98-c2ca343f7f14" width ="250"> | <img src = "https://github.com/user-attachments/assets/eba97d12-e51b-4028-8291-e9c42bfd15a4" width ="250"> |
| 수집함 | <img src = "https://github.com/user-attachments/assets/a7c7b11e-a1f5-4534-b895-59f1f0eb878e" width ="250"> | <img src = "https://github.com/user-attachments/assets/1f8492df-9723-49c9-9270-150274a32b08" width ="250"> |

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #519 